### PR TITLE
fix: prettier and eslint disagreement on print width

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "printWidth": 120
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "UNLICENSED",
   "scripts": {
     "build": "nest build",
-    "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\" --print-width=120",
+    "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",


### PR DESCRIPTION
- prettier was called with a command line arg override in package.json
- this made formatting incompatible with our linter
- moved printWidth to .prettierrc to fix this issue

TODO: a few small linting issues to be fixed (e.g. prefer const) to be done when we dont have multiple PRs open to prevent conflict headaches