### PR TITLE
User-scoped + manager-scoped transaction signing support (`fromUserId`) with improved E2E coverage

### DIFF
--- a/src/chain/chain.service.spec.ts
+++ b/src/chain/chain.service.spec.ts
@@ -250,10 +250,8 @@ describe('ChainService', () => {
       // Use a valid dummy Algorand address for all address options.
       const dummyAddress1 = 'IXQNL3EO457FGY2IWRCNP6ZZW45KCTFBEAYZN337ZJ4NB4VZ5OG62WX2ZE';
       const dummyAddress2 = 'MONEYMBRSMUAM2NGL6PCEQEDVHFWAQB6DU47NUS6P5DJM4OJFN7E7DSVBA';
-      const dummyAddress3 = 'DMYOIEE6HAIQF5QUF4XGNBL4GUZOZF6RFQCCB2NXP35AKK2674HBILQQLA';
       const clawbackAddress = dummyAddress1;
       const senderAddress = dummyAddress2;
-      const receiverAddress = dummyAddress3;
       const assetId = 1234n;
       const amount = 2n;
       const note = 'note: clawback note';
@@ -262,7 +260,6 @@ describe('ChainService', () => {
       const result = await chainService.craftAssetClawbackTx(
         clawbackAddress,
         senderAddress,
-        receiverAddress,
         assetId,
         amount,
         leaseB64,
@@ -271,7 +268,7 @@ describe('ChainService', () => {
       expect(result).toBeInstanceOf(Uint8Array);
       expect(new AlgorandEncoder().decodeTransaction(result)).toStrictEqual({
         aamt: 2,
-        arcv: new AlgorandEncoder().decodeAddress(receiverAddress),
+        arcv: new AlgorandEncoder().decodeAddress(clawbackAddress),
         fee: 1000,
         fv: 1,
         gen: 'test-genesis-id',
@@ -296,22 +293,14 @@ describe('ChainService', () => {
       // Use a valid dummy Algorand address for all address options.
       const dummyAddress1 = 'IXQNL3EO457FGY2IWRCNP6ZZW45KCTFBEAYZN337ZJ4NB4VZ5OG62WX2ZE';
       const dummyAddress2 = 'MONEYMBRSMUAM2NGL6PCEQEDVHFWAQB6DU47NUS6P5DJM4OJFN7E7DSVBA';
-      const dummyAddress3 = 'DMYOIEE6HAIQF5QUF4XGNBL4GUZOZF6RFQCCB2NXP35AKK2674HBILQQLA';
       const clawbackAddress = dummyAddress1;
       const senderAddress = dummyAddress2;
-      const receiverAddress = dummyAddress3;
       const assetId = 1234n;
       const amount = 0n;
-      const result = await chainService.craftAssetClawbackTx(
-        clawbackAddress,
-        senderAddress,
-        receiverAddress,
-        assetId,
-        amount,
-      );
+      const result = await chainService.craftAssetClawbackTx(clawbackAddress, senderAddress, assetId, amount);
       expect(result).toBeInstanceOf(Uint8Array);
       expect(new AlgorandEncoder().decodeTransaction(result)).toStrictEqual({
-        arcv: new AlgorandEncoder().decodeAddress(receiverAddress),
+        arcv: new AlgorandEncoder().decodeAddress(clawbackAddress),
         fee: 1000,
         fv: 1,
         gen: 'test-genesis-id',

--- a/src/chain/chain.service.ts
+++ b/src/chain/chain.service.ts
@@ -106,7 +106,11 @@ export class ChainService {
       .addFirstValidRound(suggested_params.lastRound)
       .addLastValidRound(suggested_params.lastRound + 1000n);
 
-    if (options.assetId) {
+    if (options.assetId !== undefined && options.assetId !== 0) {
+      const invalidAssetId = options.assetId < 0;
+      if (invalidAssetId) {
+        throw new InternalServerErrorException('assetId must be greater than 0');
+      }
       transactionBuilder.addAssetId(options.assetId);
     }
 
@@ -175,7 +179,6 @@ export class ChainService {
   async craftAssetClawbackTx(
     clawbackAddress: string,
     from: string,
-    to: string,
     asset_id: bigint,
     amount: number | bigint,
     lease?: string,
@@ -191,7 +194,7 @@ export class ChainService {
     builder.addAssetId(asset_id);
     builder.addSender(clawbackAddress);
     builder.addAssetSender(from);
-    builder.addAssetReceiver(to);
+    builder.addAssetReceiver(clawbackAddress);
     builder.addFee(suggested_params.minFee);
     builder.addFirstValidRound(suggested_params.lastRound);
     builder.addLastValidRound(suggested_params.lastRound + 1000n);

--- a/src/chain/chain.service.ts
+++ b/src/chain/chain.service.ts
@@ -217,7 +217,7 @@ export class ChainService {
   }
 
   async craftAppCallTx(
-    managerPublicAddress: string,
+    fromAddress: string,
     appCallRequestDto: AppCallRequestDto,
     suggested_params: TruncatedSuggestedParamsResponse,
     fee?: number,
@@ -226,7 +226,7 @@ export class ChainService {
       this.configService.get('GENESIS_ID'),
       this.configService.get('GENESIS_HASH'),
     );
-    builder.addSender(managerPublicAddress);
+    builder.addSender(fromAddress);
     builder.addFee(fee ?? suggested_params.minFee);
     builder.addFirstValidRound(suggested_params.lastRound);
     builder.addLastValidRound(suggested_params.lastRound + 1000n);

--- a/src/chain/chain.service.ts
+++ b/src/chain/chain.service.ts
@@ -96,7 +96,6 @@ export class ChainService {
     if (options.reserveAddress) paramsBuilder.addReserveAddress(options.reserveAddress);
     if (options.freezeAddress) paramsBuilder.addFreezeAddress(options.freezeAddress);
     if (options.clawbackAddress) paramsBuilder.addClawbackAddress(options.clawbackAddress);
-    
 
     const params = paramsBuilder.get();
     if (options.url) params.au = options.url;
@@ -522,7 +521,6 @@ export class ChainService {
     const response = await this.makeAlgoNodeRequest('v2/status', 'GET');
     return BigInt(response['last-round']);
   }
-
 
   /**
    * Submits a transaction or transactions to the Algorand network.

--- a/src/chain/chain.service.ts
+++ b/src/chain/chain.service.ts
@@ -80,6 +80,7 @@ export class ChainService {
       reserveAddress?: string;
       freezeAddress?: string;
       clawbackAddress?: string;
+      assetId?: number;
     },
   ): Promise<Uint8Array> {
     const crafter = this.getCrafter();
@@ -95,6 +96,7 @@ export class ChainService {
     if (options.reserveAddress) paramsBuilder.addReserveAddress(options.reserveAddress);
     if (options.freezeAddress) paramsBuilder.addFreezeAddress(options.freezeAddress);
     if (options.clawbackAddress) paramsBuilder.addClawbackAddress(options.clawbackAddress);
+    
 
     const params = paramsBuilder.get();
     if (options.url) params.au = options.url;
@@ -104,6 +106,10 @@ export class ChainService {
       .addFee(suggested_params.minFee)
       .addFirstValidRound(suggested_params.lastRound)
       .addLastValidRound(suggested_params.lastRound + 1000n);
+
+    if (options.assetId) {
+      transactionBuilder.addAssetId(options.assetId);
+    }
 
     return transactionBuilder.get().encode();
   }
@@ -516,6 +522,7 @@ export class ChainService {
     const response = await this.makeAlgoNodeRequest('v2/status', 'GET');
     return BigInt(response['last-round']);
   }
+
 
   /**
    * Submits a transaction or transactions to the Algorand network.

--- a/src/wallet/asset-clawback-request.dto.ts
+++ b/src/wallet/asset-clawback-request.dto.ts
@@ -17,12 +17,13 @@ export class AssetClawbackRequestDto {
   })
   userId: string;
 
+  @IsOptional()
   @IsString()
   @ApiProperty({
     example: 'manager',
-    description: 'The id of the User / Manager who signs and submits the clawback transaction',
+    description: 'Optional id of the User / Manager who clawbacks the Asset. If omitted, the implicit manager signer is used for backwards compatibility.',
   })
-  fromUserId: string;
+  fromUserId?: string = 'manager';
 
   @IsNumber()
   @ApiProperty({

--- a/src/wallet/asset-clawback-request.dto.ts
+++ b/src/wallet/asset-clawback-request.dto.ts
@@ -21,7 +21,8 @@ export class AssetClawbackRequestDto {
   @IsString()
   @ApiProperty({
     example: 'manager',
-    description: 'Optional id of the User / Manager who clawbacks the Asset. If omitted, the implicit manager signer is used for backwards compatibility.',
+    description:
+      'Optional id of the User / Manager who clawbacks the Asset. If omitted, the implicit manager signer is used for backwards compatibility.',
   })
   fromUserId?: string = 'manager';
 

--- a/src/wallet/asset-clawback-request.dto.ts
+++ b/src/wallet/asset-clawback-request.dto.ts
@@ -17,6 +17,13 @@ export class AssetClawbackRequestDto {
   })
   userId: string;
 
+  @IsString()
+  @ApiProperty({
+    example: 'manager',
+    description: 'The id of the User / Manager who signs and submits the clawback transaction',
+  })
+  fromUserId: string;
+
   @IsNumber()
   @ApiProperty({
     example: 10,

--- a/src/wallet/asset-transfer-request.dto.ts
+++ b/src/wallet/asset-transfer-request.dto.ts
@@ -17,6 +17,13 @@ export class AssetTransferRequestDto {
   })
   userId: string;
 
+  @IsString()
+  @ApiProperty({
+    example: '1234',
+    description: 'The id of the User / Manager who transfers the Asset',
+  })
+  fromUserId: string;
+
   @IsNumber()
   @ApiProperty({
     example: 10,

--- a/src/wallet/asset-transfer-request.dto.ts
+++ b/src/wallet/asset-transfer-request.dto.ts
@@ -21,7 +21,8 @@ export class AssetTransferRequestDto {
   @IsOptional()
   @ApiProperty({
     example: '1234',
-    description: 'Optional id of the User / Manager who transfers the Asset. If omitted, the implicit manager signer is used for backwards compatibility.',
+    description:
+      'Optional id of the User / Manager who transfers the Asset. If omitted, the implicit manager signer is used for backwards compatibility.',
   })
   fromUserId?: string = 'manager';
 

--- a/src/wallet/asset-transfer-request.dto.ts
+++ b/src/wallet/asset-transfer-request.dto.ts
@@ -18,11 +18,12 @@ export class AssetTransferRequestDto {
   userId: string;
 
   @IsString()
+  @IsOptional()
   @ApiProperty({
     example: '1234',
-    description: 'The id of the User / Manager who transfers the Asset',
+    description: 'Optional id of the User / Manager who transfers the Asset. If omitted, the implicit manager signer is used for backwards compatibility.',
   })
-  fromUserId: string;
+  fromUserId?: string = 'manager';
 
   @IsNumber()
   @ApiProperty({

--- a/src/wallet/create-asset.dto.ts
+++ b/src/wallet/create-asset.dto.ts
@@ -88,7 +88,8 @@ export class CreateAssetDto {
   @IsOptional()
   @ApiProperty({
     example: '1234',
-    description: 'Optional id of the User / Manager who creates the Asset. If omitted, the implicit manager signer is used for backwards compatibility.',
+    description:
+      'Optional id of the User / Manager who creates the Asset. If omitted, the implicit manager signer is used for backwards compatibility.',
   })
   fromUserId?: string = 'manager';
 }

--- a/src/wallet/create-asset.dto.ts
+++ b/src/wallet/create-asset.dto.ts
@@ -76,4 +76,19 @@ export class CreateAssetDto {
     description: 'The public address of the clawback',
   })
   clawbackAddress?: string;
+
+  @IsOptional()
+  @Transform((val) => BigInt(val.value))
+  @ApiProperty({
+    example: 1234567890,
+    description: 'The id of the Asset to config',
+  })
+  assetId: number;
+
+  @IsString()
+  @ApiProperty({
+    example: '1234',
+    description: 'The User-Id or manager that is creating the Asset',
+  })
+  fromUserId: string;
 }

--- a/src/wallet/create-asset.dto.ts
+++ b/src/wallet/create-asset.dto.ts
@@ -78,17 +78,17 @@ export class CreateAssetDto {
   clawbackAddress?: string;
 
   @IsOptional()
-  @Transform((val) => BigInt(val.value))
   @ApiProperty({
     example: 1234567890,
     description: 'The id of the Asset to config',
   })
-  assetId: number;
+  assetId?: number;
 
   @IsString()
+  @IsOptional()
   @ApiProperty({
     example: '1234',
-    description: 'The User-Id or manager that is creating the Asset',
+    description: 'Optional id of the User / Manager who creates the Asset. If omitted, the implicit manager signer is used for backwards compatibility.',
   })
-  fromUserId: string;
+  fromUserId?: string = 'manager';
 }

--- a/src/wallet/wallet.controller.spec.ts
+++ b/src/wallet/wallet.controller.spec.ts
@@ -142,7 +142,8 @@ describe('Wallet Controller', () => {
         unitName: 'UNIT',
         assetName: 'Test Asset',
         url: 'http://example.com/asset',
-        // optional properties like managerAddress, reserveAddress etc. can be added as needed
+        fromUserId: 'manager',
+        assetId: 0,
       };
       const expectedTransactionId = 'tx123456789';
 
@@ -164,6 +165,7 @@ describe('Wallet Controller', () => {
       const assetTransferRequest: AssetTransferRequestDto = {
         assetId: 123n,
         userId: 'user456',
+        fromUserId: 'manager',
         amount: 10,
         lease: '9kykoZ1IpuOAqhzDgRVaVY2ME0ZlCNrUpnzxpXlEF/s=',
         note: 'This is my note. I am not proud of it but it is what it is.',
@@ -183,6 +185,7 @@ describe('Wallet Controller', () => {
         vaultToken,
         assetTransferRequest.assetId,
         assetTransferRequest.userId,
+        assetTransferRequest.fromUserId,
         assetTransferRequest.amount,
         assetTransferRequest.lease,
         assetTransferRequest.note,
@@ -195,9 +198,10 @@ describe('Wallet Controller', () => {
     it('should clawback an asset and return the transaction id', async () => {
       const vaultToken = 'vault-token-jkl';
       const assetClawbackRequest: AssetClawbackRequestDto = {
-        assetId: 123n,
-        userId: 'user456',
-        amount: 10,
+        assetId: 10n,
+        userId: 'user_123',
+        fromUserId: 'manager',
+        amount: 100,
         lease: '9kykoZ1IpuOAqhzDgRVaVY2ME0ZlCNrUpnzxpXlEF/s=',
         note: 'This is my note. I am not proud of it but it is what it is.',
       };
@@ -212,6 +216,7 @@ describe('Wallet Controller', () => {
         vaultToken,
         assetClawbackRequest.assetId,
         assetClawbackRequest.userId,
+        assetClawbackRequest.fromUserId,
         assetClawbackRequest.amount,
         assetClawbackRequest.lease,
         assetClawbackRequest.note,

--- a/src/wallet/wallet.controller.ts
+++ b/src/wallet/wallet.controller.ts
@@ -230,6 +230,7 @@ export class Wallet {
         request.vault_token,
         assetClawbackRequestDto.assetId,
         assetClawbackRequestDto.userId,
+        assetClawbackRequestDto.fromUserId,
         assetClawbackRequestDto.amount,
         assetClawbackRequestDto.lease,
         assetClawbackRequestDto.note,

--- a/src/wallet/wallet.controller.ts
+++ b/src/wallet/wallet.controller.ts
@@ -278,7 +278,8 @@ export class Wallet {
   })
   async groupTx(@Request() request: any, @Body() groupRequestDto: GroupRequestDto) {
     return {
-      group_id: await this.walletService.groupTransaction(request.vault_token, groupRequestDto),
+      group_id: await this.walletService.groupTransaction(
+        request.vault_token, groupRequestDto ),
     };
   }
 }

--- a/src/wallet/wallet.controller.ts
+++ b/src/wallet/wallet.controller.ts
@@ -278,8 +278,7 @@ export class Wallet {
   })
   async groupTx(@Request() request: any, @Body() groupRequestDto: GroupRequestDto) {
     return {
-      group_id: await this.walletService.groupTransaction(
-        request.vault_token, groupRequestDto ),
+      group_id: await this.walletService.groupTransaction(request.vault_token, groupRequestDto),
     };
   }
 }

--- a/src/wallet/wallet.controller.ts
+++ b/src/wallet/wallet.controller.ts
@@ -165,6 +165,7 @@ export class Wallet {
         request.vault_token,
         assetTransferRequestDto.assetId,
         assetTransferRequestDto.userId,
+        assetTransferRequestDto.fromUserId,
         assetTransferRequestDto.amount,
         assetTransferRequestDto.lease,
         assetTransferRequestDto.note,

--- a/src/wallet/wallet.service.spec.ts
+++ b/src/wallet/wallet.service.spec.ts
@@ -537,7 +537,6 @@ describe('WalletService', () => {
         1,
         managerPublicAddress,
         userPublicAddress,
-        managerPublicAddress,
         assetId,
         amount,
         lease,

--- a/src/wallet/wallet.service.spec.ts
+++ b/src/wallet/wallet.service.spec.ts
@@ -149,6 +149,8 @@ describe('WalletService', () => {
       reserveAddress: address,
       freezeAddress: address,
       clawbackAddress: address,
+      fromUserId: 'manager',
+      assetId: 0,
     };
 
     const vaultToken = 'vault_token';
@@ -230,7 +232,7 @@ describe('WalletService', () => {
       chainServiceMock.getAccountBalance.mockResolvedValueOnce(algoBalance);
 
       // Call
-      const result = await walletService.transferAsset(vaultToken, assetId, userId, amount);
+      const result = await walletService.transferAsset(vaultToken, assetId, userId, 'manager', amount);
 
       // Verify the flow.
       expect(vaultServiceMock.getUserPublicKey).toHaveBeenCalledWith(userId, vaultToken);
@@ -275,10 +277,10 @@ describe('WalletService', () => {
         dummySignedManagerTx2,
       ]);
 
-      expect(result).toBe('final_tx_id');
+      expect(result).toEqual('final_tx_id');
     });
 
-    it('transferAsset() -- user exists -- not opted in -- not enough algo', async () => {
+    it('clawbackAsset() -- user exists -- not opted in -- not enough algo', async () => {
       chainServiceMock.getAccountAsset.mockResolvedValueOnce(null); // user has not opted in
       chainServiceMock.getAccountDetail.mockResolvedValueOnce({
         amount: 100100n,
@@ -291,7 +293,7 @@ describe('WalletService', () => {
       chainServiceMock.getAccountBalance.mockResolvedValueOnce(algoBalance);
 
       // Call
-      const result = await walletService.transferAsset(vaultToken, assetId, userId, amount);
+      const result = await walletService.transferAsset(vaultToken, assetId, userId, 'manager', amount);
 
       // Verify the flow.
       expect(vaultServiceMock.getUserPublicKey).toHaveBeenCalledWith(userId, vaultToken);
@@ -351,7 +353,7 @@ describe('WalletService', () => {
       chainServiceMock.getAccountBalance.mockResolvedValueOnce(algoBalance);
 
       // Call
-      const result = await walletService.transferAsset(vaultToken, assetId, userId, amount);
+      const result = await walletService.transferAsset(vaultToken, assetId, userId, 'manager', amount);
 
       // Verify the flow.
       expect(vaultServiceMock.getUserPublicKey).toHaveBeenCalledWith(userId, vaultToken);
@@ -394,7 +396,7 @@ describe('WalletService', () => {
       chainServiceMock.getAccountBalance.mockResolvedValueOnce(algoBalance);
 
       // Call
-      const result = await walletService.transferAsset(vaultToken, assetId, userId, amount, lease, note);
+      const result = await walletService.transferAsset(vaultToken, assetId, userId, 'manager', amount, lease, note);
 
       // Verify the flow.
       expect(vaultServiceMock.getUserPublicKey).toHaveBeenCalledWith(userId, vaultToken);
@@ -437,7 +439,7 @@ describe('WalletService', () => {
       chainServiceMock.getAccountBalance.mockResolvedValueOnce(algoBalance);
 
       // Call
-      const result = await walletService.transferAsset(vaultToken, assetId, userId, amount);
+      const result = await walletService.transferAsset(vaultToken, assetId, userId, 'manager', amount);
 
       // Verify the flow.
       expect(vaultServiceMock.getUserPublicKey).toHaveBeenCalledWith(userId, vaultToken);
@@ -524,7 +526,7 @@ describe('WalletService', () => {
     });
     it('clawbackAsset() -- test clawback', async () => {
       // Call
-      const result = await walletService.clawbackAsset(vaultToken, assetId, userId, amount, lease, note);
+      const result = await walletService.clawbackAsset(vaultToken, assetId, userId, 'manager', amount, lease, note);
 
       // Verify the flow.
       expect(vaultServiceMock.getUserPublicKey).toHaveBeenCalledWith(userId, vaultToken);

--- a/src/wallet/wallet.service.ts
+++ b/src/wallet/wallet.service.ts
@@ -140,7 +140,7 @@ export class WalletService {
 
   async createAsset(options: CreateAssetDto, vault_token: string) {
     const fromAddress = await this.getFromAddress(options.fromUserId, vault_token);
-    
+
     const tx: Uint8Array<ArrayBufferLike> = await this.chainService.craftAssetCreateTx(fromAddress, options);
     const signedTx: Uint8Array<ArrayBufferLike> =
       options.fromUserId === 'manager'
@@ -239,8 +239,8 @@ export class WalletService {
     note?: string,
   ) {
     const userPublicAddress: string = (await this.getUserInfo(userId, vault_token)).public_address;
-    
-    const fromAddress = await this.getFromAddress(fromUserId, vault_token)
+
+    const fromAddress = await this.getFromAddress(fromUserId, vault_token);
 
     const suggested_params = await this.chainService.getSuggestedParams();
 
@@ -273,12 +273,7 @@ export class WalletService {
     const unSignedTxs: Uint8Array[] = [];
     if (willPaymentTx) {
       unSignedTxs.push(
-        await this.chainService.craftPaymentTx(
-          fromAddress,
-          userPublicAddress,
-          userExtraAlgoNeed,
-          suggested_params,
-        ),
+        await this.chainService.craftPaymentTx(fromAddress, userPublicAddress, userExtraAlgoNeed, suggested_params),
       );
     }
     if (willOptInTx) {
@@ -323,8 +318,12 @@ export class WalletService {
       if (isUserTx) {
         signedTxs.push(await this.signTxAsUser(userId, tx, vault_token));
       } else {
-        signedTxs.push(fromUserId == 'manager'? await this.signTxAsManager(tx, vault_token) : await this.signTxAsUser(fromUserId, tx, vault_token));
-      } 
+        signedTxs.push(
+          fromUserId == 'manager'
+            ? await this.signTxAsManager(tx, vault_token)
+            : await this.signTxAsUser(fromUserId, tx, vault_token),
+        );
+      }
       // else {
       //   throw new Error('Invalid sender');
       // }
@@ -422,7 +421,7 @@ export class WalletService {
         fromAddress = (await this.getUserInfo(appCallRequestDto.fromUserId, vault_token)).public_address;
       }
     } catch (error) {
-      throw error
+      throw error;
     }
 
     const suggested_params = await this.chainService.getSuggestedParams();
@@ -481,7 +480,7 @@ export class WalletService {
           const fromAddress = await this.getFromAddress(value.fromUserId, vault_token);
 
           senderIds.push(value.fromUserId);
-          
+
           const tx = await this.chainService.craftAppCallTx(fromAddress, value, suggested_params, value.fee);
           unSignedTxs.push(tx);
           break;
@@ -496,7 +495,7 @@ export class WalletService {
         case 'assetTransfer': {
           const fromAddress = await this.getFromAddress(value.fromUserId, vault_token);
           senderIds.push(value.fromUserId);
-          
+
           const userPublicAddress: string = (await this.getUserInfo(value.userId, vault_token)).public_address;
           const tx = await this.chainService.craftAssetTransferTx(
             fromAddress,

--- a/src/wallet/wallet.service.ts
+++ b/src/wallet/wallet.service.ts
@@ -549,7 +549,6 @@ export class WalletService {
       throw new Error('No transactions to group');
     }
 
-    const encoder = new AlgorandEncoder();
     const groupedTxns: Uint8Array[] = this.chainService.setGroupID(unSignedTxs);
 
     if (senderIds.length !== groupedTxns.length) {

--- a/src/wallet/wallet.service.ts
+++ b/src/wallet/wallet.service.ts
@@ -177,10 +177,7 @@ export class WalletService {
         fromAddress = (await this.getUserInfo(fromUserId, vault_token)).public_address;
       }
     } catch (error) {
-      if (error instanceof HttpException) {
-        throw error;
-      }
-      throw new Error(`Failed to get from address for user ${fromUserId}: ${error.message}`);
+      this.throwHttpError(error, `Failed to get from address for user ${fromUserId}`);
     }
 
     Logger.debug(`Transferring ${amount} Algos from ${fromUserId} (${fromAddress}) to ${toAddress}`);
@@ -205,10 +202,7 @@ export class WalletService {
       // submit transaction
       return (await this.chainService.submitTransaction(signedTx)).txid;
     } catch (error) {
-      if (error instanceof HttpException) {
-        throw error;
-      }
-      throw new Error(`Failed to sign transaction as user ${fromUserId}: ${error.message}`);
+      this.throwHttpError(error, `Failed to sign/submit transaction as ${fromUserId}`);
     }
   }
 
@@ -312,8 +306,6 @@ export class WalletService {
       const encoder: AlgorandEncoder = new AlgorandEncoder();
       const isUserTx: boolean =
         encoder.encodeAddress(Buffer.from(encoder.decodeTransaction(tx).snd)) == userPublicAddress;
-      // const isManagerTx: boolean =
-      //   encoder.encodeAddress(Buffer.from(encoder.decodeTransaction(tx).snd)) == managerPublicAddress;
 
       if (isUserTx) {
         signedTxs.push(await this.signTxAsUser(userId, tx, vault_token));
@@ -324,9 +316,6 @@ export class WalletService {
             : await this.signTxAsUser(fromUserId, tx, vault_token),
         );
       }
-      // else {
-      //   throw new Error('Invalid sender');
-      // }
     }
 
     return (await this.chainService.submitTransaction(signedTxs)).txid;
@@ -362,10 +351,7 @@ export class WalletService {
     try {
       fromAddress = await this.getFromAddress(fromUserId, vault_token);
     } catch (error) {
-      if (error instanceof HttpException) {
-        throw error;
-      }
-      throw new Error(`Failed to get from address for user ${fromUserId}: ${error.message}`);
+      this.throwHttpError(error, `Failed to get from address for user ${fromUserId}`);
     }
 
     const suggested_params = await this.chainService.getSuggestedParams();
@@ -374,7 +360,6 @@ export class WalletService {
     const tx: Uint8Array<ArrayBufferLike> = await this.chainService.craftAssetClawbackTx(
       fromAddress,
       userPublicAddress,
-      fromAddress,
       assetId,
       amount,
       lease,
@@ -389,10 +374,7 @@ export class WalletService {
           ? await this.signTxAsManager(tx, vault_token)
           : await this.signTxAsUser(fromUserId, tx, vault_token);
     } catch (error) {
-      if (error instanceof HttpException) {
-        throw error;
-      }
-      throw new Error(`Failed to sign transaction as user ${fromUserId}: ${error.message}`);
+      this.throwHttpError(error, `Failed to sign clawback transaction as ${fromUserId}`);
     }
 
     const transactionId: string = (await this.chainService.submitTransaction(signedTx)).txid;
@@ -421,7 +403,7 @@ export class WalletService {
         fromAddress = (await this.getUserInfo(appCallRequestDto.fromUserId, vault_token)).public_address;
       }
     } catch (error) {
-      throw error;
+      this.throwHttpError(error, `Failed to get from address for user ${appCallRequestDto.fromUserId}`);
     }
 
     const suggested_params = await this.chainService.getSuggestedParams();
@@ -446,7 +428,7 @@ export class WalletService {
       // submit transaction
       return (await this.chainService.submitTransaction(signedTx)).txid;
     } catch (error) {
-      throw new Error(`Failed to sign transaction as user ${appCallRequestDto.fromUserId}: ${error.message}`);
+      this.throwHttpError(error, `Failed to sign/submit app call as ${appCallRequestDto.fromUserId}`);
     }
   }
 
@@ -475,27 +457,21 @@ export class WalletService {
         throw new Error('Invalid transaction step');
       }
 
+      const fromAddress = await this.getFromAddress(value.fromUserId, vault_token);
+      senderIds.push(value.fromUserId);
+
       switch (key) {
         case 'appCall': {
-          const fromAddress = await this.getFromAddress(value.fromUserId, vault_token);
-
-          senderIds.push(value.fromUserId);
-
           const tx = await this.chainService.craftAppCallTx(fromAddress, value, suggested_params, value.fee);
           unSignedTxs.push(tx);
           break;
         }
         case 'assetConfig': {
-          const fromAddress = await this.getFromAddress(value.fromUserId, vault_token);
-          senderIds.push(value.fromUserId);
           const tx = await this.chainService.craftAssetCreateTx(fromAddress, value);
           unSignedTxs.push(tx);
           break;
         }
         case 'assetTransfer': {
-          const fromAddress = await this.getFromAddress(value.fromUserId, vault_token);
-          senderIds.push(value.fromUserId);
-
           const userPublicAddress: string = (await this.getUserInfo(value.userId, vault_token)).public_address;
           const tx = await this.chainService.craftAssetTransferTx(
             fromAddress,
@@ -510,9 +486,6 @@ export class WalletService {
           break;
         }
         case 'payment': {
-          const fromAddress = await this.getFromAddress(value.fromUserId, vault_token);
-          senderIds.push(value.fromUserId);
-
           const tx = await this.chainService.craftPaymentTx(
             fromAddress,
             value.toAddress,
@@ -523,14 +496,10 @@ export class WalletService {
           break;
         }
         case 'assetClawback': {
-          const fromAddress = await this.getFromAddress('manager', vault_token);
-          senderIds.push(value.fromUserId);
-
           const userPublicAddress: string = (await this.getUserInfo(value.userId, vault_token)).public_address;
           const tx = await this.chainService.craftAssetClawbackTx(
             fromAddress,
             userPublicAddress,
-            fromAddress,
             value.assetId,
             value.amount,
             value.lease,
@@ -573,7 +542,7 @@ export class WalletService {
     return txid;
   }
 
-  async getFromAddress(userId: any, vault_token: string): Promise<string> {
+  async getFromAddress(userId: string, vault_token: string): Promise<string> {
     if (userId == 'manager') {
       const managerPublicKey: Buffer = await this.vaultService.getManagerPublicKey(vault_token);
       const managerPublicAddress: string = new AlgorandEncoder().encodeAddress(managerPublicKey);
@@ -583,5 +552,29 @@ export class WalletService {
       const userPublicAddress: string = new AlgorandEncoder().encodeAddress(userPublicKey);
       return userPublicAddress;
     }
+  }
+
+  private getErrorStatus(error: unknown): number | undefined {
+    const maybeAny = error as any;
+    if (error instanceof HttpException) {
+      return error.getStatus();
+    }
+    if (typeof maybeAny?.status === 'number') return maybeAny.status;
+    if (typeof maybeAny?.statusCode === 'number') return maybeAny.statusCode;
+    if (typeof maybeAny?.response?.status === 'number') return maybeAny.response.status;
+    return undefined;
+  }
+
+  private throwHttpError(error: unknown, context: string): never {
+    if (error instanceof HttpException) {
+      throw error;
+    }
+
+    const status = this.getErrorStatus(error);
+    const maybeAny = error as any;
+    const message = `${context}${status !== undefined ? ` (status ${status})` : ''}: ${maybeAny?.message ?? String(error)}`;
+    const httpError = new HttpException(message, status ?? 500);
+    (httpError as any).cause = error;
+    throw httpError;
   }
 }

--- a/src/wallet/wallet.service.ts
+++ b/src/wallet/wallet.service.ts
@@ -352,21 +352,30 @@ export class WalletService {
     vault_token: string,
     assetId: bigint,
     userId: string,
+    fromUserId: string,
     amount: number,
     lease?: string,
     note?: string,
   ) {
     const userPublicAddress: string = (await this.getUserInfo(userId, vault_token)).public_address;
-    const managerPublicKey: Buffer = await this.vaultService.getManagerPublicKey(vault_token);
-    const managerPublicAddress: string = new AlgorandEncoder().encodeAddress(managerPublicKey);
+    let fromAddress: string;
+
+    try {
+      fromAddress = await this.getFromAddress(fromUserId, vault_token);
+    } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      throw new Error(`Failed to get from address for user ${fromUserId}: ${error.message}`);
+    }
 
     const suggested_params = await this.chainService.getSuggestedParams();
 
     // build unsigned tx
     const tx: Uint8Array<ArrayBufferLike> = await this.chainService.craftAssetClawbackTx(
-      managerPublicAddress,
+      fromAddress,
       userPublicAddress,
-      managerPublicAddress,
+      fromAddress,
       assetId,
       amount,
       lease,
@@ -374,9 +383,19 @@ export class WalletService {
       suggested_params,
     );
 
-    // sign tx by manager
+    let signedTx: Uint8Array<ArrayBufferLike>;
+    try {
+      signedTx =
+        fromUserId === 'manager'
+          ? await this.signTxAsManager(tx, vault_token)
+          : await this.signTxAsUser(fromUserId, tx, vault_token);
+    } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+      throw new Error(`Failed to sign transaction as user ${fromUserId}: ${error.message}`);
+    }
 
-    const signedTx: Uint8Array<ArrayBufferLike> = await this.signTxAsManager(tx, vault_token);
     const transactionId: string = (await this.chainService.submitTransaction(signedTx)).txid;
 
     return transactionId;
@@ -403,7 +422,7 @@ export class WalletService {
         fromAddress = (await this.getUserInfo(appCallRequestDto.fromUserId, vault_token)).public_address;
       }
     } catch (error) {
-      throw new Error(`Failed to get from address for user ${appCallRequestDto.fromUserId}: ${error.message}`);
+      throw error
     }
 
     const suggested_params = await this.chainService.getSuggestedParams();

--- a/src/wallet/wallet.service.ts
+++ b/src/wallet/wallet.service.ts
@@ -460,19 +460,14 @@ export class WalletService {
    * @returns The group transaction ID (the txid of the first transaction in the submitted group).
    */
   async groupTransaction(vault_token: string, groupRequestDto: GroupRequestDto) {
-    const managerPublicKey: Buffer = await this.vaultService.getManagerPublicKey(vault_token);
-    const managerPublicAddress: string = new AlgorandEncoder().encodeAddress(managerPublicKey);
-
     const suggested_params = await this.chainService.getSuggestedParams();
-
-    Logger.debug(`Group Request DTO: ${groupRequestDto}`);
 
     if (!Array.isArray((groupRequestDto as any).transactions) || groupRequestDto.transactions.length === 0) {
       throw new Error('transactions is required and must be a non-empty array');
     }
 
     const unSignedTxs: Uint8Array[] = [];
-    const addressToUserId: Record<string, string> = {};
+    const senderIds: string[] = [];
 
     for (const step of groupRequestDto.transactions) {
       const key = (step as any).type as string;
@@ -483,27 +478,28 @@ export class WalletService {
 
       switch (key) {
         case 'appCall': {
-          let fromAddress: string;
-          if (value.fromUserId === 'manager') {
-            fromAddress = managerPublicAddress;
-          } else {
-            fromAddress = (await this.getUserInfo(value.fromUserId, vault_token)).public_address;
-            addressToUserId[fromAddress] = value.fromUserId;
-          }
+          const fromAddress = await this.getFromAddress(value.fromUserId, vault_token);
 
+          senderIds.push(value.fromUserId);
+          
           const tx = await this.chainService.craftAppCallTx(fromAddress, value, suggested_params, value.fee);
           unSignedTxs.push(tx);
           break;
         }
         case 'assetConfig': {
-          const tx = await this.chainService.craftAssetCreateTx(managerPublicAddress, value);
+          const fromAddress = await this.getFromAddress(value.fromUserId, vault_token);
+          senderIds.push(value.fromUserId);
+          const tx = await this.chainService.craftAssetCreateTx(fromAddress, value);
           unSignedTxs.push(tx);
           break;
         }
         case 'assetTransfer': {
+          const fromAddress = await this.getFromAddress(value.fromUserId, vault_token);
+          senderIds.push(value.fromUserId);
+          
           const userPublicAddress: string = (await this.getUserInfo(value.userId, vault_token)).public_address;
           const tx = await this.chainService.craftAssetTransferTx(
-            managerPublicAddress,
+            fromAddress,
             userPublicAddress,
             value.assetId,
             value.amount,
@@ -515,13 +511,8 @@ export class WalletService {
           break;
         }
         case 'payment': {
-          let fromAddress: string;
-          if (value.fromUserId === 'manager') {
-            fromAddress = managerPublicAddress;
-          } else {
-            fromAddress = (await this.getUserInfo(value.fromUserId, vault_token)).public_address;
-            addressToUserId[fromAddress] = value.fromUserId;
-          }
+          const fromAddress = await this.getFromAddress(value.fromUserId, vault_token);
+          senderIds.push(value.fromUserId);
 
           const tx = await this.chainService.craftPaymentTx(
             fromAddress,
@@ -533,11 +524,14 @@ export class WalletService {
           break;
         }
         case 'assetClawback': {
+          const fromAddress = await this.getFromAddress('manager', vault_token);
+          senderIds.push(value.fromUserId);
+
           const userPublicAddress: string = (await this.getUserInfo(value.userId, vault_token)).public_address;
           const tx = await this.chainService.craftAssetClawbackTx(
-            managerPublicAddress,
+            fromAddress,
             userPublicAddress,
-            managerPublicAddress,
+            fromAddress,
             value.assetId,
             value.amount,
             value.lease,
@@ -559,13 +553,18 @@ export class WalletService {
     const encoder = new AlgorandEncoder();
     const groupedTxns: Uint8Array[] = this.chainService.setGroupID(unSignedTxs);
 
+    if (senderIds.length !== groupedTxns.length) {
+      throw new Error('Invalid group signer mapping');
+    }
+
     const signedTxs: Uint8Array[] = [];
-    for (const tx of groupedTxns) {
-      const sender = encoder.encodeAddress(Buffer.from(encoder.decodeTransaction(tx).snd));
-      if (sender === managerPublicAddress) {
+    for (let i = 0; i < groupedTxns.length; i++) {
+      const tx = groupedTxns[i];
+      const senderId = senderIds[i];
+      if (senderId === 'manager') {
         signedTxs.push(await this.signTxAsManager(tx, vault_token));
-      } else if (addressToUserId[sender]) {
-        signedTxs.push(await this.signTxAsUser(addressToUserId[sender], tx, vault_token));
+      } else if (senderId) {
+        signedTxs.push(await this.signTxAsUser(senderId, tx, vault_token));
       } else {
         throw new Error('Invalid sender');
       }

--- a/src/wallet/wallet.service.ts
+++ b/src/wallet/wallet.service.ts
@@ -139,10 +139,13 @@ export class WalletService {
   }
 
   async createAsset(options: CreateAssetDto, vault_token: string) {
-    const managerPublicKey: Buffer = await this.vaultService.getManagerPublicKey(vault_token);
-    const managerPublicAddress: string = new AlgorandEncoder().encodeAddress(managerPublicKey);
-    const tx: Uint8Array<ArrayBufferLike> = await this.chainService.craftAssetCreateTx(managerPublicAddress, options);
-    const signedTx: Uint8Array<ArrayBufferLike> = await this.signTxAsManager(tx, vault_token);
+    const fromAddress = await this.getFromAddress(options.fromUserId, vault_token);
+    
+    const tx: Uint8Array<ArrayBufferLike> = await this.chainService.craftAssetCreateTx(fromAddress, options);
+    const signedTx: Uint8Array<ArrayBufferLike> =
+      options.fromUserId === 'manager'
+        ? await this.signTxAsManager(tx, vault_token)
+        : await this.signTxAsUser(options.fromUserId, tx, vault_token);
     const transactionId: string = (await this.chainService.submitTransaction(signedTx)).txid;
 
     return transactionId;
@@ -543,5 +546,17 @@ export class WalletService {
     const txid = (await this.chainService.submitTransaction(signedTxs)).txid;
 
     return txid;
+  }
+
+  async getFromAddress(userId: any, vault_token: string): Promise<string> {
+    if (userId == 'manager') {
+      const managerPublicKey: Buffer = await this.vaultService.getManagerPublicKey(vault_token);
+      const managerPublicAddress: string = new AlgorandEncoder().encodeAddress(managerPublicKey);
+      return managerPublicAddress;
+    } else {
+      const userPublicKey: Buffer = await this.vaultService.getUserPublicKey(userId, vault_token);
+      const userPublicAddress: string = new AlgorandEncoder().encodeAddress(userPublicKey);
+      return userPublicAddress;
+    }
   }
 }

--- a/src/wallet/wallet.service.ts
+++ b/src/wallet/wallet.service.ts
@@ -457,6 +457,11 @@ export class WalletService {
         throw new Error('Invalid transaction step');
       }
 
+      const supportedTypes = new Set(['appCall', 'assetConfig', 'assetTransfer', 'payment', 'assetClawback']);
+      if (!supportedTypes.has(key)) {
+        throw new Error(`Unsupported transaction type: ${key}`);
+      }
+
       const fromAddress = await this.getFromAddress(value.fromUserId, vault_token);
       senderIds.push(value.fromUserId);
 
@@ -509,8 +514,6 @@ export class WalletService {
           unSignedTxs.push(tx);
           break;
         }
-        default:
-          throw new Error(`Unsupported transaction type: ${key}`);
       }
     }
 

--- a/src/wallet/wallet.service.ts
+++ b/src/wallet/wallet.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, HttpException } from '@nestjs/common';
 import { VaultService } from '../vault/vault.service';
 import { ChainService } from '../chain/chain.service';
 import { CreateAssetDto } from './create-asset.dto';
@@ -177,6 +177,9 @@ export class WalletService {
         fromAddress = (await this.getUserInfo(fromUserId, vault_token)).public_address;
       }
     } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
       throw new Error(`Failed to get from address for user ${fromUserId}: ${error.message}`);
     }
 
@@ -202,6 +205,9 @@ export class WalletService {
       // submit transaction
       return (await this.chainService.submitTransaction(signedTx)).txid;
     } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
       throw new Error(`Failed to sign transaction as user ${fromUserId}: ${error.message}`);
     }
   }
@@ -216,6 +222,7 @@ export class WalletService {
    *
    * @param assetId The ID of the asset to be transferred.
    * @param userId The ID of the user receiving the asset.
+   * @param fromUserId The ID of the user sending the asset.
    * @param amount The amount of the asset to be transferred.
    * @param lease An optional 32 byte lease encoded as base64.
    * @param note An optional transaction note.
@@ -226,13 +233,14 @@ export class WalletService {
     vault_token: string,
     assetId: bigint,
     userId: string,
+    fromUserId: string,
     amount: number,
     lease?: string,
     note?: string,
   ) {
     const userPublicAddress: string = (await this.getUserInfo(userId, vault_token)).public_address;
-    const managerPublicKey: Buffer = await this.vaultService.getManagerPublicKey(vault_token);
-    const managerPublicAddress: string = new AlgorandEncoder().encodeAddress(managerPublicKey);
+    
+    const fromAddress = await this.getFromAddress(fromUserId, vault_token)
 
     const suggested_params = await this.chainService.getSuggestedParams();
 
@@ -266,7 +274,7 @@ export class WalletService {
     if (willPaymentTx) {
       unSignedTxs.push(
         await this.chainService.craftPaymentTx(
-          managerPublicAddress,
+          fromAddress,
           userPublicAddress,
           userExtraAlgoNeed,
           suggested_params,
@@ -288,7 +296,7 @@ export class WalletService {
     }
     unSignedTxs.push(
       await this.chainService.craftAssetTransferTx(
-        managerPublicAddress,
+        fromAddress,
         userPublicAddress,
         assetId,
         amount,
@@ -309,16 +317,17 @@ export class WalletService {
       const encoder: AlgorandEncoder = new AlgorandEncoder();
       const isUserTx: boolean =
         encoder.encodeAddress(Buffer.from(encoder.decodeTransaction(tx).snd)) == userPublicAddress;
-      const isManagerTx: boolean =
-        encoder.encodeAddress(Buffer.from(encoder.decodeTransaction(tx).snd)) == managerPublicAddress;
+      // const isManagerTx: boolean =
+      //   encoder.encodeAddress(Buffer.from(encoder.decodeTransaction(tx).snd)) == managerPublicAddress;
 
       if (isUserTx) {
         signedTxs.push(await this.signTxAsUser(userId, tx, vault_token));
-      } else if (isManagerTx) {
-        signedTxs.push(await this.signTxAsManager(tx, vault_token));
       } else {
-        throw new Error('Invalid sender');
-      }
+        signedTxs.push(fromUserId == 'manager'? await this.signTxAsManager(tx, vault_token) : await this.signTxAsUser(fromUserId, tx, vault_token));
+      } 
+      // else {
+      //   throw new Error('Invalid sender');
+      // }
     }
 
     return (await this.chainService.submitTransaction(signedTxs)).txid;

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1301,18 +1301,19 @@ describe('App E2E', () => {
     }, 60000);
   });
 
-  describe.only('Group transactions', () => {
+  describe('Group transactions', () => {
     let managerAccessToken: string;
     let deployedAppId = 0;
     let deployedAppAddress: string;
     let tokenAssetId = 0;
     let userAccessToken: string;
     let groupUserId: string;
+    let groupReceiverAddress: string;
     let userDeployedAppId = 0;
 
     beforeAll(async () => {
-      const vaultToken = await loginToVault(MANAGER_ROLE_AND_SECRET);
-      managerAccessToken = await signInToPawn(vaultToken);
+      const managerVaultToken = await loginToVault(MANAGER_ROLE_AND_SECRET);
+      managerAccessToken = await signInToPawn(managerVaultToken);
 
       deployedAppId = 754755349;
       deployedAppAddress = 'CHIJEK5EF3DD6EHCM23CV6IXO7JI4YIOHGN6755G6X3NQVYVKJV3WM7M2A';
@@ -1322,12 +1323,23 @@ describe('App E2E', () => {
       expect(createUserResponse.status).toBe(201);
       groupUserId = userId;
 
+      const { userId: receiverUserId, createUserResponse: receiverCreateUserResponse } = await createNewUser(managerAccessToken);
+      expect(receiverCreateUserResponse.status).toBe(201);
+      groupReceiverAddress = receiverCreateUserResponse.data.public_address;
+
       const fundUserResponse = await axios.post(
         `${APP_BASE_URL}/wallet/transactions/transfer-algo`,
         { fromUserId: 'manager', toAddress: createUserResponse.data.public_address, amount: 500000 },
         { headers: { Authorization: `Bearer ${managerAccessToken}` } },
       );
       expect(fundUserResponse.status).toBe(201);
+
+      const fundReceiverResponse = await axios.post(
+        `${APP_BASE_URL}/wallet/transactions/transfer-algo`,
+        { fromUserId: 'manager', toAddress: groupReceiverAddress, amount: 500000 },
+        { headers: { Authorization: `Bearer ${managerAccessToken}` } },
+      );
+      expect(fundReceiverResponse.status).toBe(201);
 
       const userVaultToken = await loginToVault(USER_ROLE_AND_SECRET);
       userAccessToken = await signInToPawn(userVaultToken);
@@ -1453,21 +1465,21 @@ describe('App E2E', () => {
     });
 
     describe('Group transaction (user scoped)', () => {
-      it('(FAIL) user role should not be able to sign any group transaction as manager', async () => {
+      it('(FAIL) user role should not be able to submit group transaction with mixed signers', async () => {
         const groupRequestData = {
           transactions: [
             {
               type: 'payment',
               payload: {
-                toAddress: deployedAppAddress,
-                amount: 100000,
+                toAddress: groupReceiverAddress,
+                amount: 1000,
                 fromUserId: 'manager',
               },
             },
             {
               type: 'payment',
               payload: {
-                toAddress: deployedAppAddress,
+                toAddress: groupReceiverAddress,
                 amount: 1000,
                 fromUserId: groupUserId,
               },
@@ -1490,7 +1502,7 @@ describe('App E2E', () => {
             {
               type: 'payment',
               payload: {
-                toAddress: deployedAppAddress,
+                toAddress: groupReceiverAddress,
                 amount: 1000,
                 fromUserId: groupUserId,
               },

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -72,10 +72,28 @@ describe('App E2E', () => {
     return manager_detail_response.data.public_address;
   };
 
+  const getUserAddress = async (userId: string) => {
+    const vaultToken = await loginToVault(USER_ROLE_AND_SECRET);
+    const accessToken = await signInToPawn(vaultToken);
+
+    const user_detail_response = await axios.get(`${APP_BASE_URL}/wallet/users/${userId}/`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    return user_detail_response.data.public_address;
+  };
+
   // Function to get account detail
   const getAccountDetail = async (address: string) => {
     const chainService = new ChainService(new ConfigService(), new HttpService());
     return await chainService.getAccountDetail(address);
+  };
+
+  const getTransaction = async (transactionId: string) => {
+    const indexerBaseUrl = process.env.ALGORAND_INDEXER_BASE_URL ?? 'https://testnet-idx.4160.nodely.dev';
+    const response = await axios.get(`${indexerBaseUrl}/v2/transactions/${transactionId}`, {
+      headers: { accept: 'application/json' },
+    });
+    return response.data;
   };
 
   describe('AUTH', () => {
@@ -265,7 +283,7 @@ describe('App E2E', () => {
      * @property {string} freezeAddress - The address of the asset freeze.
      * @property {string} clawbackAddress - The address of the asset clawback.
      */
-    const assetData = {
+    var assetData = {
       total: 100000,
       decimals: 0,
       defaultFrozen: false,
@@ -276,12 +294,16 @@ describe('App E2E', () => {
       reserveAddress: 'I3345FUQQ2GRBHFZQPLYQQX5HJMMRZMABCHRLWV6RCJYC6OO4MOLEUBEGU',
       freezeAddress: 'I3345FUQQ2GRBHFZQPLYQQX5HJMMRZMABCHRLWV6RCJYC6OO4MOLEUBEGU',
       clawbackAddress: 'I3345FUQQ2GRBHFZQPLYQQX5HJMMRZMABCHRLWV6RCJYC6OO4MOLEUBEGU',
+      fromUserId: '',
+      assetId: 0
     };
 
     // Test to verify that a user with the manager role can create an asset
     it('(OK) Can create with manager role', async () => {
       const vaultToken = await loginToVault(MANAGER_ROLE_AND_SECRET);
       const accessToken = await signInToPawn(vaultToken);
+
+      assetData.fromUserId = 'manager';
 
       try {
         const response = await axios.post(`${APP_BASE_URL}/wallet/transactions/create-asset`, assetData, {
@@ -295,12 +317,34 @@ describe('App E2E', () => {
           `Unexpected Error.\nYou have to add some algo to manager addrees: ${await getManagerAddress()}\nYou can use https://bank.testnet.algorand.network/`,
         );
       }
-    }, 60000);
-
-    // Test to verify that a user with the user role cannot create an asset
-    it('(FAIL) Can not create with user role', async () => {
+    }, 60000); 
+    
+    it('(OK) Can create with user role and user as signer', async () => {
       const vaultToken = await loginToVault(USER_ROLE_AND_SECRET);
       const accessToken = await signInToPawn(vaultToken);
+
+      assetData.fromUserId = 'test_user';
+
+      try {
+        const response = await axios.post(`${APP_BASE_URL}/wallet/transactions/create-asset`, assetData, {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+
+        expect(response.status).toBe(201); // HTTP 201 Created
+        expect(typeof response.data.transaction_id).toEqual('string');
+      } catch {
+        throw new Error(
+          `Unexpected Error.\nYou have to add some algo to manager addrees: ${await getUserAddress('test_user')}\nYou can use https://bank.testnet.algorand.network/`,
+        );
+      }
+    }, 60000); 
+
+    // Test to verify that a user with the user role cannot create an asset
+    it('(FAIL) Can not create with user role and manager as signer', async () => {
+      const vaultToken = await loginToVault(USER_ROLE_AND_SECRET);
+      const accessToken = await signInToPawn(vaultToken);
+
+      assetData.fromUserId = 'manager';
 
       await expect(
         axios.post(`${APP_BASE_URL}/wallet/transactions/create-asset`, assetData, {
@@ -308,6 +352,46 @@ describe('App E2E', () => {
         }),
       ).rejects.toMatchObject({ response: { status: 403 } }); // HTTP 403 Forbidden
     }, 60000);
+
+    it('(OK) Can manage asset ACL', async () => {
+      const vaultToken = await loginToVault(MANAGER_ROLE_AND_SECRET);
+      const accessToken = await signInToPawn(vaultToken);
+
+      assetData.fromUserId = 'manager';
+      assetData.managerAddress = await getManagerAddress();
+
+      try {
+        const response = await axios.post(`${APP_BASE_URL}/wallet/transactions/create-asset`, assetData, {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+
+        expect(response.status).toBe(201); // HTTP 201 Created
+        expect(typeof response.data.transaction_id).toEqual('string');
+
+        const transaction = await getTransaction(response.data.transaction_id);
+
+        expect(typeof transaction.transaction['created-asset-index']).toEqual('number');
+        
+        assetData.assetId = transaction.transaction['created-asset-index'];
+        assetData.clawbackAddress = await getUserAddress('test_user');
+
+
+        const response2 = await axios.post(`${APP_BASE_URL}/wallet/transactions/create-asset`, assetData, {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        });
+
+        expect(response2.status).toBe(201); // HTTP 201 Created
+        expect(typeof response2.data.transaction_id).toEqual('string');
+        
+
+      } catch {
+        throw new Error(
+          `Unexpected Error.\nYou have to add some algo to manager addrees: ${await getManagerAddress()}\nYou can use https://bank.testnet.algorand.network/`,
+        );
+      }
+
+      
+    }, 60000); 
   });
 
   describe('Transfer Algo', () => {

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -349,11 +349,14 @@ describe('App E2E', () => {
 
       try {
 
-          const fundUserWallet = await axios.post(
+        const fundUserWallet = await axios.post(
           `${APP_BASE_URL}/wallet/transactions/transfer-algo`,
           { fromUserId: 'manager', toAddress: createUserResponse.data.public_address, amount: 201000 },
           { headers: { Authorization: `Bearer ${managerAccessToken}` } },
         );
+
+        expect(fundUserWallet.status).toBe(201)
+        expect(typeof fundUserWallet.data.transaction_id).toEqual('string');
 
         assetData.fromUserId = userId
 
@@ -425,7 +428,7 @@ describe('App E2E', () => {
     }, 60000); 
   });
 
-  describe('Transfer Algo', () => {
+  describe.only('Transfer Algo', () => {
     it('(OK) transfer algo to address from manager', async () => {
       const vaultToken = await loginToVault(MANAGER_ROLE_AND_SECRET);
       const managerAccessToken = await signInToPawn(vaultToken);
@@ -449,9 +452,55 @@ describe('App E2E', () => {
       expect(userDetailResponse.status).toBe(200);
       expect(userDetailResponse.data.algoBalance).toBe('1000000');
     }, 60000);
+
+    it('(FAIL) User role cannot transfer algo with manager as signer', async () => {
+      const userVaultToken = await loginToVault(USER_ROLE_AND_SECRET);
+      const userAccessToken = await signInToPawn(userVaultToken);
+
+      const managerVaultToken = await loginToVault(MANAGER_ROLE_AND_SECRET);
+      const managerAccessToken = await signInToPawn(managerVaultToken);
+
+      const { createUserResponse } = await createNewUser(managerAccessToken);
+
+      await expect(
+        axios.post(
+          `${APP_BASE_URL}/wallet/transactions/transfer-algo`,
+          { fromUserId: 'manager', toAddress: createUserResponse.data.public_address, amount: 100000 },
+          { headers: { Authorization: `Bearer ${userAccessToken}` } },
+        ),
+      ).rejects.toMatchObject({ response: { status: 403 } });
+    }, 60000);
+
+    it('(OK) User role can transfer algo with user as signer', async () => {
+      const userVaultToken = await loginToVault(USER_ROLE_AND_SECRET);
+      const userAccessToken = await signInToPawn(userVaultToken);
+
+      const managerVaultToken = await loginToVault(MANAGER_ROLE_AND_SECRET);
+      const managerAccessToken = await signInToPawn(managerVaultToken);
+
+      const { userId: senderUserId, createUserResponse: senderUser } = await createNewUser(managerAccessToken);
+      const { createUserResponse: receiverUser } = await createNewUser(managerAccessToken);
+
+      // Fund sender so they can pay the transfer fee and amount.
+      const fundResponse = await axios.post(
+        `${APP_BASE_URL}/wallet/transactions/transfer-algo`,
+        { fromUserId: 'manager', toAddress: senderUser.data.public_address, amount: 1000000 },
+        { headers: { Authorization: `Bearer ${managerAccessToken}` } },
+      );
+      expect(fundResponse.status).toBe(201);
+
+      const transferResponse = await axios.post(
+        `${APP_BASE_URL}/wallet/transactions/transfer-algo`,
+        { fromUserId: senderUserId, toAddress: receiverUser.data.public_address, amount: 100000 },
+        { headers: { Authorization: `Bearer ${userAccessToken}` } },
+      );
+
+      expect(transferResponse.status).toBe(201);
+      expect(typeof transferResponse.data.transaction_id).toEqual('string');
+    }, 60000);
   });
 
-  describe('Transfer Asset', () => {
+  describe('Transfer asset with the manager as the signer', () => {
     /**
      * Represents the data structure for an asset transfer.
      *
@@ -465,6 +514,7 @@ describe('App E2E', () => {
       userId: 'test-user-id',
       amount: 1,
       lease: undefined,
+      fromUserId: 'manager'
     };
 
     let assetId: bigint | number;
@@ -593,6 +643,179 @@ describe('App E2E', () => {
       assetTransferRequestData.assetId = Number(assetId);
       assetTransferRequestData.userId = userId;
       assetTransferRequestData.amount = 2;
+
+      // Adds a lease to the transaction to prevent replay and conflicting transactions.
+      // The lease (a 32-byte base64-encoded string) locks the {Sender, Lease} pair until LastValid round expires,
+      // ensuring only one transaction with that lease can be confirmed during that window.
+      // Use a consistent lease value if retrying or managing exclusivity; generating a new random lease each time
+      // prevents replay but won't prevent conflicting submissions.
+      // To generate a lease: Buffer.from(crypto.randomBytes(32)).toString('base64')
+      assetTransferRequestData.lease = Buffer.from(randomBytes(32)).toString('base64');
+
+      // Transfer the asset
+
+      const response1 = await axios.post(
+        `${APP_BASE_URL}/wallet/transactions/transfer-asset`,
+        assetTransferRequestData,
+        {
+          headers: { Authorization: `Bearer ${managerAccessToken}` },
+        },
+      );
+      expect(response1.status).toBe(201); // HTTP 201 Created
+      expect(typeof response1.data.transaction_id).toEqual('string');
+
+      // transfer it again
+      assetTransferRequestData.amount = 3;
+
+      await expect(
+        axios.post(`${APP_BASE_URL}/wallet/transactions/transfer-asset`, assetTransferRequestData, {
+          headers: { Authorization: `Bearer ${managerAccessToken}` },
+        }),
+      ).rejects.toMatchObject({ response: { status: 400 } });
+    }, 60000);
+  });
+
+  describe('Transfer asset with the user as the signer', () => {
+    /**
+     * Represents the data structure for an asset transfer.
+     *
+     * @property {bigint} assetId - The ID of the asset to be transferred.
+     * @property {string} userId - The ID of the user receiving the asset.
+     * @property {number} amount - The amount of the asset to be transferred
+     * @property {string} lease - The transaction lease to be attached to the asset transfer transaction.
+     */
+    const assetTransferRequestData = {
+      assetId: 1,
+      userId: 'test-user-id',
+      amount: 1,
+      lease: undefined,
+      fromUserId: 'user'
+    };
+
+    let assetId: bigint | number;
+    let managerAccessToken: string;
+
+    beforeAll(async () => {
+      // before all tests, create an asset and set assetId
+      const vaultToken = await loginToVault(USER_ROLE_AND_SECRET);
+      const accessToken = await signInToPawn(vaultToken);
+
+      const managerVaultToken = await loginToVault(MANAGER_ROLE_AND_SECRET);
+      managerAccessToken = await signInToPawn(managerVaultToken);
+
+      const { userId, createUserResponse } = await createNewUser(managerAccessToken);
+
+      const fundUserWallet = await axios.post(
+          `${APP_BASE_URL}/wallet/transactions/transfer-algo`,
+          { fromUserId: 'manager', toAddress: createUserResponse.data.public_address, amount: 1000000 },
+          { headers: { Authorization: `Bearer ${managerAccessToken}` } },
+        );
+
+      expect(fundUserWallet.status).toBe(201)
+      expect(typeof fundUserWallet.data.transaction_id).toEqual('string');
+
+      const assetData = {
+        total: 100000,
+        decimals: 0,
+        defaultFrozen: false,
+        unitName: 'Tas',
+        assetName: 'Tennnnnnnnnnnnnnnnnn',
+        fromUserId: userId,
+        url: 'https://example.com',
+      };
+      const createAssetResponse = await axios.post(`${APP_BASE_URL}/wallet/transactions/create-asset`, assetData, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      expect(createAssetResponse.status).toBe(201); // HTTP 201 Created
+
+      
+
+      const userDetail = await getAccountDetail(createUserResponse.data.public_address);
+      assetId = userDetail.assets.reduce((max, current) => (current.assetId > max.assetId ? current : max), {
+        assetId: 0,
+      }).assetId;
+      if (assetId == 0) {
+        throw new Error('User does not have asset to testing transfer.');
+      }
+
+      assetTransferRequestData.fromUserId = userId;
+      
+
+    }, 60000);
+
+    afterAll(() => {
+      assetTransferRequestData.amount = 1;
+      assetTransferRequestData.lease = undefined;
+    });
+
+    it('(OK) transfer asset', async () => {
+      const vaultToken = await loginToVault(USER_ROLE_AND_SECRET);
+      const accessToken = await signInToPawn(vaultToken);
+
+      // Create new user
+
+      const { userId, createUserResponse } = await createNewUser(managerAccessToken);
+      expect(createUserResponse.status).toBe(201);
+
+      assetTransferRequestData.assetId = Number(assetId);
+      assetTransferRequestData.userId = userId;
+      // assetTransferRequestData.fromUserId = fromUserId;
+
+      // Transfer the asset
+
+      const response1 = await axios.post(
+        `${APP_BASE_URL}/wallet/transactions/transfer-asset`,
+        assetTransferRequestData,
+        {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        },
+      );
+      expect(response1.status).toBe(201); // HTTP 201 Created
+      expect(typeof response1.data.transaction_id).toEqual('string');
+
+      // transfer it again
+
+      const response2 = await axios.post(
+        `${APP_BASE_URL}/wallet/transactions/transfer-asset`,
+        assetTransferRequestData,
+        {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        },
+      );
+      expect(response2.status).toBe(201); // HTTP 201 Created
+      expect(typeof response2.data.transaction_id).toEqual('string');
+
+      // ############################################################
+      // Check if the asset is transferred to the user by fetching the user's account balance
+      const responseAssetHoldings = await axios.get(`${APP_BASE_URL}/wallet/assets/${userId}`, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      expect(responseAssetHoldings.status).toBe(200); // HTTP 200 OK
+      expect(responseAssetHoldings.data).toHaveProperty('address');
+      expect(responseAssetHoldings.data).toHaveProperty('assets');
+      expect(responseAssetHoldings.data.assets).toBeInstanceOf(Array);
+      expect(responseAssetHoldings.data.assets.length).toBeGreaterThan(0);
+      expect(responseAssetHoldings.data.assets[0]).toHaveProperty('amount');
+      expect(responseAssetHoldings.data.assets[0]).toHaveProperty('asset-id');
+      expect(responseAssetHoldings.data.assets[0]['asset-id']).toEqual(assetTransferRequestData.assetId);
+      expect(responseAssetHoldings.data.assets[0].amount).toEqual(assetTransferRequestData.amount * 2);
+      // ############################################################
+    }, 60000);
+
+
+    it('(FAIL) can not transfer asset twice with same lease', async () => {
+      const vaultToken = await loginToVault(USER_ROLE_AND_SECRET);
+      const accessToken = await signInToPawn(vaultToken);
+
+      // Create new user
+
+      const { userId, createUserResponse } = await createNewUser(managerAccessToken);
+      expect(createUserResponse.status).toBe(201);
+
+      assetTransferRequestData.assetId = Number(assetId);
+      assetTransferRequestData.userId = userId;
+      assetTransferRequestData.amount = 2;
+      // assetTransferRequestData.fromUserId = fromUserId;
 
       // Adds a lease to the transaction to prevent replay and conflicting transactions.
       // The lease (a 32-byte base64-encoded string) locks the {Sender, Lease} pair until LastValid round expires,

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -96,6 +96,24 @@ describe('App E2E', () => {
     return response.data;
   };
 
+  const createNewUser = async(managerAccessToken: string) => {
+    // Create new user
+      const userId = randomBytes(32).toString('hex');
+      const createUserResponse = await axios.post(
+        `${APP_BASE_URL}/wallet/user/`,
+        { user_id: userId },
+        {
+          headers: {
+            Authorization: `Bearer ${managerAccessToken}`,
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+          },
+        },
+      );
+
+      return { userId, createUserResponse };
+  };
+
   describe('AUTH', () => {
     // Test to verify that a user can sign in to the application
     it('(OK) Can sign in', async () => {
@@ -323,9 +341,22 @@ describe('App E2E', () => {
       const vaultToken = await loginToVault(USER_ROLE_AND_SECRET);
       const accessToken = await signInToPawn(vaultToken);
 
-      assetData.fromUserId = 'test_user';
+      const managerVaultToken = await loginToVault(MANAGER_ROLE_AND_SECRET);
+      const managerAccessToken = await signInToPawn(managerVaultToken);
+
+      const { userId, createUserResponse } = await createNewUser(managerAccessToken);
+
 
       try {
+
+          const fundUserWallet = await axios.post(
+          `${APP_BASE_URL}/wallet/transactions/transfer-algo`,
+          { fromUserId: 'manager', toAddress: createUserResponse.data.public_address, amount: 201000 },
+          { headers: { Authorization: `Bearer ${managerAccessToken}` } },
+        );
+
+        assetData.fromUserId = userId
+
         const response = await axios.post(`${APP_BASE_URL}/wallet/transactions/create-asset`, assetData, {
           headers: { Authorization: `Bearer ${accessToken}` },
         });
@@ -334,7 +365,7 @@ describe('App E2E', () => {
         expect(typeof response.data.transaction_id).toEqual('string');
       } catch {
         throw new Error(
-          `Unexpected Error.\nYou have to add some algo to manager addrees: ${await getUserAddress('test_user')}\nYou can use https://bank.testnet.algorand.network/`,
+          `Unexpected Error.\nYou have to add some algo to manager addrees: ${await getManagerAddress()}\nYou can use https://bank.testnet.algorand.network/`,
         );
       }
     }, 60000); 
@@ -399,20 +430,8 @@ describe('App E2E', () => {
       const vaultToken = await loginToVault(MANAGER_ROLE_AND_SECRET);
       const managerAccessToken = await signInToPawn(vaultToken);
 
-      // Create new user
-      const userId = randomBytes(32).toString('hex');
-      const createUserResponse = await axios.post(
-        `${APP_BASE_URL}/wallet/user/`,
-        { user_id: userId },
-        {
-          headers: {
-            Authorization: `Bearer ${managerAccessToken}`,
-            'Content-Type': 'application/json',
-            Accept: 'application/json',
-          },
-        },
-      );
-      expect(createUserResponse.status).toBe(201);
+      // Create New user
+      const { userId, createUserResponse } = await createNewUser(managerAccessToken);
 
       // transfer from manager to new user
       const response1 = await axios.post(
@@ -461,6 +480,7 @@ describe('App E2E', () => {
         defaultFrozen: false,
         unitName: 'Tas',
         assetName: 'Tennnnnnnnnnnnnnnnnn',
+        fromUserId: 'manager',
         url: 'https://example.com',
       };
       const createAssetResponse = await axios.post(`${APP_BASE_URL}/wallet/transactions/create-asset`, assetData, {
@@ -489,18 +509,7 @@ describe('App E2E', () => {
 
       // Create new user
 
-      const userId = randomBytes(32).toString('hex');
-      const createUserResponse = await axios.post(
-        `${APP_BASE_URL}/wallet/user/`,
-        { user_id: userId },
-        {
-          headers: {
-            Authorization: `Bearer ${managerAccessToken}`,
-            'Content-Type': 'application/json',
-            Accept: 'application/json',
-          },
-        },
-      );
+      const { userId, createUserResponse } = await createNewUser(managerAccessToken);
       expect(createUserResponse.status).toBe(201);
 
       assetTransferRequestData.assetId = Number(assetId);
@@ -556,18 +565,8 @@ describe('App E2E', () => {
 
       // Create new user
 
-      const userId = randomBytes(32).toString('hex');
-      const createUserResponse = await axios.post(
-        `${APP_BASE_URL}/wallet/user/`,
-        { user_id: userId },
-        {
-          headers: {
-            Authorization: `Bearer ${managerAccessToken}`,
-            'Content-Type': 'application/json',
-            Accept: 'application/json',
-          },
-        },
-      );
+      const { userId, createUserResponse } = await createNewUser(managerAccessToken);
+
       expect(createUserResponse.status).toBe(201);
 
       assetTransferRequestData.assetId = Number(assetId);
@@ -588,18 +587,7 @@ describe('App E2E', () => {
 
       // Create new user
 
-      const userId = randomBytes(32).toString('hex');
-      const createUserResponse = await axios.post(
-        `${APP_BASE_URL}/wallet/user/`,
-        { user_id: userId },
-        {
-          headers: {
-            Authorization: `Bearer ${managerAccessToken}`,
-            'Content-Type': 'application/json',
-            Accept: 'application/json',
-          },
-        },
-      );
+      const { userId, createUserResponse } = await createNewUser(managerAccessToken);
       expect(createUserResponse.status).toBe(201);
 
       assetTransferRequestData.assetId = Number(assetId);
@@ -666,6 +654,7 @@ describe('App E2E', () => {
         unitName: 'Tas',
         assetName: 'Tennnnnnnnnnnnnnnnnn',
         url: 'https://example.com',
+        fromUserId: 'manager',
         clawbackAddress: managerAddress, // Pawn assumes clawback address is the manager address but it's needs to be set explicitly when creating the asset
       };
       const createAssetResponse = await axios.post(`${APP_BASE_URL}/wallet/transactions/create-asset`, assetData, {
@@ -692,19 +681,9 @@ describe('App E2E', () => {
 
       // Create new user
 
-      const userId = randomBytes(32).toString('hex');
-      const createUserResponse = await axios.post(
-        `${APP_BASE_URL}/wallet/user/`,
-        { user_id: userId },
-        {
-          headers: {
-            Authorization: `Bearer ${managerAccessToken}`,
-            'Content-Type': 'application/json',
-            Accept: 'application/json',
-          },
-        },
-      );
+      const { userId, createUserResponse } = await createNewUser(managerAccessToken);
       expect(createUserResponse.status).toBe(201);
+      
       assetClawbackRequestData.assetId = Number(assetId);
       assetClawbackRequestData.userId = userId;
       // Transfer the asset
@@ -752,18 +731,7 @@ describe('App E2E', () => {
 
       // Create new user
 
-      const userId = randomBytes(32).toString('hex');
-      const createUserResponse = await axios.post(
-        `${APP_BASE_URL}/wallet/user/`,
-        { user_id: userId },
-        {
-          headers: {
-            Authorization: `Bearer ${managerAccessToken}`,
-            'Content-Type': 'application/json',
-            Accept: 'application/json',
-          },
-        },
-      );
+      const { userId, createUserResponse } = await createNewUser(managerAccessToken);
       expect(createUserResponse.status).toBe(201);
 
       assetClawbackRequestData.assetId = Number(assetId);
@@ -787,6 +755,7 @@ describe('App E2E', () => {
         }),
       ).rejects.toMatchObject({ response: { status: 403 } });
     }, 60000);
+
     it('(FAIL) can not clawback asset without clawback address', async () => {
       // create asset without clawback address
       const vaultToken = await loginToVault(MANAGER_ROLE_AND_SECRET);
@@ -797,12 +766,14 @@ describe('App E2E', () => {
         defaultFrozen: false,
         unitName: 'Tas',
         assetName: 'Tennnnnnnnnnnnnnnnnn',
+        fromUserId: 'manager',
         url: 'https://example.com',
       };
       const createAssetResponse = await axios.post(`${APP_BASE_URL}/wallet/transactions/create-asset`, assetData, {
         headers: { Authorization: `Bearer ${managerAccessToken}` },
       });
       expect(createAssetResponse.status).toBe(201); // HTTP 201 Created
+
       const managerAddress = await getManagerAddress();
       const managerDetail = await getAccountDetail(managerAddress);
       assetId = managerDetail.assets.reduce((max, current) => (current.assetId > max.assetId ? current : max), {
@@ -813,19 +784,9 @@ describe('App E2E', () => {
       }
       // Create new user
 
-      const userId = randomBytes(32).toString('hex');
-      const createUserResponse = await axios.post(
-        `${APP_BASE_URL}/wallet/user/`,
-        { user_id: userId },
-        {
-          headers: {
-            Authorization: `Bearer ${managerAccessToken}`,
-            'Content-Type': 'application/json',
-            Accept: 'application/json',
-          },
-        },
-      );
+      const { userId, createUserResponse } = await createNewUser(managerAccessToken);
       expect(createUserResponse.status).toBe(201);
+
       assetClawbackRequestData.assetId = Number(assetId);
       assetClawbackRequestData.userId = userId;
       // Transfer the asset

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1174,18 +1174,20 @@ describe('App E2E', () => {
       const userAccessToken = await signInToPawn(userVaultToken);
 
       await expect(
-        axios.post(`${APP_BASE_URL}/wallet/transactions/clawback-asset`, {
-          assetId: Number(newAssetId),
-          userId: targetUserId,
-          fromUserId: userId,
-          amount: 1,
-        }, {
-          headers: { Authorization: `Bearer ${managerAccessToken}` },
-        }),
+        axios.post(
+          `${APP_BASE_URL}/wallet/transactions/clawback-asset`,
+          {
+            assetId: Number(newAssetId),
+            userId: targetUserId,
+            fromUserId: userId,
+            amount: 1,
+          },
+          {
+            headers: { Authorization: `Bearer ${userAccessToken}` },
+          },
+        ),
       ).rejects.toMatchObject({ response: { status: 400 } }); // HTTP 400 Bad Request
-
     }, 60000);
-    
   });
 
   describe('App deploy', () => {

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -301,7 +301,7 @@ describe('App E2E', () => {
      * @property {string} freezeAddress - The address of the asset freeze.
      * @property {string} clawbackAddress - The address of the asset clawback.
      */
-    var assetData = {
+    const assetData = {
       total: 100000,
       decimals: 0,
       defaultFrozen: false,
@@ -819,7 +819,7 @@ describe('App E2E', () => {
         `${APP_BASE_URL}/wallet/transactions/transfer-asset`,
         assetTransferRequestData,
         {
-          headers: { Authorization: `Bearer ${managerAccessToken}` },
+          headers: { Authorization: `Bearer ${accessToken}` },
         },
       );
       expect(response1.status).toBe(201); // HTTP 201 Created
@@ -830,7 +830,7 @@ describe('App E2E', () => {
 
       await expect(
         axios.post(`${APP_BASE_URL}/wallet/transactions/transfer-asset`, assetTransferRequestData, {
-          headers: { Authorization: `Bearer ${managerAccessToken}` },
+          headers: { Authorization: `Bearer ${accessToken}` },
         }),
       ).rejects.toMatchObject({ response: { status: 400 } });
     }, 60000);
@@ -1318,8 +1318,7 @@ describe('App E2E', () => {
       expect(createUserResponse.status).toBe(201);
       groupUserId = userId;
 
-      const { userId: receiverUserId, createUserResponse: receiverCreateUserResponse } =
-        await createNewUser(managerAccessToken);
+      const { createUserResponse: receiverCreateUserResponse } = await createNewUser(managerAccessToken);
       expect(receiverCreateUserResponse.status).toBe(201);
       groupReceiverAddress = receiverCreateUserResponse.data.public_address;
 

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -96,22 +96,22 @@ describe('App E2E', () => {
     return response.data;
   };
 
-  const createNewUser = async(managerAccessToken: string) => {
+  const createNewUser = async (managerAccessToken: string) => {
     // Create new user
-      const userId = randomBytes(32).toString('hex');
-      const createUserResponse = await axios.post(
-        `${APP_BASE_URL}/wallet/user/`,
-        { user_id: userId },
-        {
-          headers: {
-            Authorization: `Bearer ${managerAccessToken}`,
-            'Content-Type': 'application/json',
-            Accept: 'application/json',
-          },
+    const userId = randomBytes(32).toString('hex');
+    const createUserResponse = await axios.post(
+      `${APP_BASE_URL}/wallet/user/`,
+      { user_id: userId },
+      {
+        headers: {
+          Authorization: `Bearer ${managerAccessToken}`,
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
         },
-      );
+      },
+    );
 
-      return { userId, createUserResponse };
+    return { userId, createUserResponse };
   };
 
   describe('AUTH', () => {
@@ -313,7 +313,7 @@ describe('App E2E', () => {
       freezeAddress: 'I3345FUQQ2GRBHFZQPLYQQX5HJMMRZMABCHRLWV6RCJYC6OO4MOLEUBEGU',
       clawbackAddress: 'I3345FUQQ2GRBHFZQPLYQQX5HJMMRZMABCHRLWV6RCJYC6OO4MOLEUBEGU',
       fromUserId: '',
-      assetId: 0
+      assetId: 0,
     };
 
     // Test to verify that a user with the manager role can create an asset
@@ -335,8 +335,8 @@ describe('App E2E', () => {
           `Unexpected Error.\nYou have to add some algo to manager addrees: ${await getManagerAddress()}\nYou can use https://bank.testnet.algorand.network/`,
         );
       }
-    }, 60000); 
-    
+    }, 60000);
+
     it('(OK) Can create with user role and user as signer', async () => {
       const vaultToken = await loginToVault(USER_ROLE_AND_SECRET);
       const accessToken = await signInToPawn(vaultToken);
@@ -346,19 +346,17 @@ describe('App E2E', () => {
 
       const { userId, createUserResponse } = await createNewUser(managerAccessToken);
 
-
       try {
-
         const fundUserWallet = await axios.post(
           `${APP_BASE_URL}/wallet/transactions/transfer-algo`,
           { fromUserId: 'manager', toAddress: createUserResponse.data.public_address, amount: 201000 },
           { headers: { Authorization: `Bearer ${managerAccessToken}` } },
         );
 
-        expect(fundUserWallet.status).toBe(201)
+        expect(fundUserWallet.status).toBe(201);
         expect(typeof fundUserWallet.data.transaction_id).toEqual('string');
 
-        assetData.fromUserId = userId
+        assetData.fromUserId = userId;
 
         const response = await axios.post(`${APP_BASE_URL}/wallet/transactions/create-asset`, assetData, {
           headers: { Authorization: `Bearer ${accessToken}` },
@@ -371,7 +369,7 @@ describe('App E2E', () => {
           `Unexpected Error.\nYou have to add some algo to manager addrees: ${await getManagerAddress()}\nYou can use https://bank.testnet.algorand.network/`,
         );
       }
-    }, 60000); 
+    }, 60000);
 
     // Test to verify that a user with the user role cannot create an asset
     it('(FAIL) Can not create with user role and manager as signer', async () => {
@@ -405,10 +403,9 @@ describe('App E2E', () => {
         const transaction = await getTransaction(response.data.transaction_id);
 
         expect(typeof transaction.transaction['created-asset-index']).toEqual('number');
-        
+
         assetData.assetId = transaction.transaction['created-asset-index'];
         assetData.clawbackAddress = await getUserAddress('test_user');
-
 
         const response2 = await axios.post(`${APP_BASE_URL}/wallet/transactions/create-asset`, assetData, {
           headers: { Authorization: `Bearer ${accessToken}` },
@@ -416,16 +413,12 @@ describe('App E2E', () => {
 
         expect(response2.status).toBe(201); // HTTP 201 Created
         expect(typeof response2.data.transaction_id).toEqual('string');
-        
-
       } catch {
         throw new Error(
           `Unexpected Error.\nYou have to add some algo to manager addrees: ${await getManagerAddress()}\nYou can use https://bank.testnet.algorand.network/`,
         );
       }
-
-      
-    }, 60000); 
+    }, 60000);
   });
 
   describe('Transfer Algo', () => {
@@ -514,7 +507,7 @@ describe('App E2E', () => {
       userId: 'test-user-id',
       amount: 1,
       lease: undefined,
-      fromUserId: 'manager'
+      fromUserId: 'manager',
     };
 
     let assetId: bigint | number;
@@ -689,7 +682,7 @@ describe('App E2E', () => {
       userId: 'test-user-id',
       amount: 1,
       lease: undefined,
-      fromUserId: 'user'
+      fromUserId: 'user',
     };
 
     let assetId: bigint | number;
@@ -706,12 +699,12 @@ describe('App E2E', () => {
       const { userId, createUserResponse } = await createNewUser(managerAccessToken);
 
       const fundUserWallet = await axios.post(
-          `${APP_BASE_URL}/wallet/transactions/transfer-algo`,
-          { fromUserId: 'manager', toAddress: createUserResponse.data.public_address, amount: 1000000 },
-          { headers: { Authorization: `Bearer ${managerAccessToken}` } },
-        );
+        `${APP_BASE_URL}/wallet/transactions/transfer-algo`,
+        { fromUserId: 'manager', toAddress: createUserResponse.data.public_address, amount: 1000000 },
+        { headers: { Authorization: `Bearer ${managerAccessToken}` } },
+      );
 
-      expect(fundUserWallet.status).toBe(201)
+      expect(fundUserWallet.status).toBe(201);
       expect(typeof fundUserWallet.data.transaction_id).toEqual('string');
 
       const assetData = {
@@ -728,8 +721,6 @@ describe('App E2E', () => {
       });
       expect(createAssetResponse.status).toBe(201); // HTTP 201 Created
 
-      
-
       const userDetail = await getAccountDetail(createUserResponse.data.public_address);
       assetId = userDetail.assets.reduce((max, current) => (current.assetId > max.assetId ? current : max), {
         assetId: 0,
@@ -739,8 +730,6 @@ describe('App E2E', () => {
       }
 
       assetTransferRequestData.fromUserId = userId;
-      
-
     }, 60000);
 
     afterAll(() => {
@@ -801,7 +790,6 @@ describe('App E2E', () => {
       expect(responseAssetHoldings.data.assets[0].amount).toEqual(assetTransferRequestData.amount * 2);
       // ############################################################
     }, 60000);
-
 
     it('(FAIL) can not transfer asset twice with same lease', async () => {
       const vaultToken = await loginToVault(USER_ROLE_AND_SECRET);
@@ -907,7 +895,7 @@ describe('App E2E', () => {
 
       const { userId, createUserResponse } = await createNewUser(managerAccessToken);
       expect(createUserResponse.status).toBe(201);
-      
+
       assetClawbackRequestData.assetId = Number(assetId);
       assetClawbackRequestData.userId = userId;
       // Transfer the asset
@@ -1017,9 +1005,12 @@ describe('App E2E', () => {
       expect(createAssetResponse.status).toBe(201);
 
       const managerDetail = await getAccountDetail(managerAddress);
-      const newAssetId = managerDetail.assets.reduce((max, current) => (current.assetId > max.assetId ? current : max), {
-        assetId: 0,
-      }).assetId;
+      const newAssetId = managerDetail.assets.reduce(
+        (max, current) => (current.assetId > max.assetId ? current : max),
+        {
+          assetId: 0,
+        },
+      ).assetId;
       if (newAssetId == 0) {
         throw new Error('Manager does not have asset to testing clawback.');
       }
@@ -1174,9 +1165,13 @@ describe('App E2E', () => {
         fromUserId: appUserId,
       };
 
-      const userCreateResponse = await axios.post(`${APP_BASE_URL}/wallet/transactions/app-call/`, userAppCreateRequestData, {
-        headers: { Authorization: `Bearer ${userAccessToken}` },
-      });
+      const userCreateResponse = await axios.post(
+        `${APP_BASE_URL}/wallet/transactions/app-call/`,
+        userAppCreateRequestData,
+        {
+          headers: { Authorization: `Bearer ${userAccessToken}` },
+        },
+      );
       expect(userCreateResponse.status).toBe(201);
       expect(typeof userCreateResponse.data.transaction_id).toEqual('string');
 
@@ -1323,7 +1318,8 @@ describe('App E2E', () => {
       expect(createUserResponse.status).toBe(201);
       groupUserId = userId;
 
-      const { userId: receiverUserId, createUserResponse: receiverCreateUserResponse } = await createNewUser(managerAccessToken);
+      const { userId: receiverUserId, createUserResponse: receiverCreateUserResponse } =
+        await createNewUser(managerAccessToken);
       expect(receiverCreateUserResponse.status).toBe(201);
       groupReceiverAddress = receiverCreateUserResponse.data.public_address;
 
@@ -1356,9 +1352,13 @@ describe('App E2E', () => {
         fromUserId: groupUserId,
       };
 
-      const userCreateResponse = await axios.post(`${APP_BASE_URL}/wallet/transactions/app-call/`, userAppCreateRequestData, {
-        headers: { Authorization: `Bearer ${userAccessToken}` },
-      });
+      const userCreateResponse = await axios.post(
+        `${APP_BASE_URL}/wallet/transactions/app-call/`,
+        userAppCreateRequestData,
+        {
+          headers: { Authorization: `Bearer ${userAccessToken}` },
+        },
+      );
       expect(userCreateResponse.status).toBe(201);
       expect(typeof userCreateResponse.data.transaction_id).toEqual('string');
 

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -332,7 +332,7 @@ describe('App E2E', () => {
         expect(typeof response.data.transaction_id).toEqual('string');
       } catch {
         throw new Error(
-          `Unexpected Error.\nYou have to add some algo to manager addrees: ${await getManagerAddress()}\nYou can use https://bank.testnet.algorand.network/`,
+          `Unexpected Error.\nYou have to add some algo to manager address: ${await getManagerAddress()}\nYou can use https://bank.testnet.algorand.network/`,
         );
       }
     }, 60000);
@@ -748,7 +748,6 @@ describe('App E2E', () => {
 
       assetTransferRequestData.assetId = Number(assetId);
       assetTransferRequestData.userId = userId;
-      // assetTransferRequestData.fromUserId = fromUserId;
 
       // Transfer the asset
 
@@ -1103,6 +1102,90 @@ describe('App E2E', () => {
         }),
       ).rejects.toMatchObject({ response: { status: 400 } }); // HTTP 400 Bad Request
     }, 60000);
+
+    it('(FAIL) can not clawback asset if user address is not clawback address', async () => {
+      const managerVaultToken = await loginToVault(MANAGER_ROLE_AND_SECRET);
+      const managerAccessToken = await signInToPawn(managerVaultToken);
+
+      // Create a user who will be set as the asset clawback address (and signer)
+      const { userId: clawbackUserId, createUserResponse: clawbackUser } = await createNewUser(managerAccessToken);
+      expect(clawbackUser.status).toBe(201);
+
+      // Create a target user who will receive the asset and then be clawed back
+      const { userId: targetUserId, createUserResponse: targetUser } = await createNewUser(managerAccessToken);
+      expect(targetUser.status).toBe(201);
+
+      const { userId: userId, createUserResponse: user } = await createNewUser(managerAccessToken);
+      expect(user.status).toBe(201);
+
+      // Ensure clawback user has enough ALGO to pay transaction fees
+      const fundClawbackUser = await axios.post(
+        `${APP_BASE_URL}/wallet/transactions/transfer-algo`,
+        { fromUserId: 'manager', toAddress: clawbackUser.data.public_address, amount: 500000 },
+        { headers: { Authorization: `Bearer ${managerAccessToken}` } },
+      );
+      expect(fundClawbackUser.status).toBe(201);
+
+      const managerAddress = await getManagerAddress();
+      const assetData = {
+        total: 100000,
+        decimals: 0,
+        defaultFrozen: false,
+        unitName: 'Tas',
+        assetName: 'Tennnnnnnnnnnnnnnnnn',
+        url: 'https://example.com',
+        fromUserId: 'manager',
+        clawbackAddress: clawbackUser.data.public_address,
+      };
+      const createAssetResponse = await axios.post(`${APP_BASE_URL}/wallet/transactions/create-asset`, assetData, {
+        headers: { Authorization: `Bearer ${managerAccessToken}` },
+      });
+      expect(createAssetResponse.status).toBe(201);
+
+      const managerDetail = await getAccountDetail(managerAddress);
+      const newAssetId = managerDetail.assets.reduce(
+        (max, current) => (current.assetId > max.assetId ? current : max),
+        {
+          assetId: 0,
+        },
+      ).assetId;
+      if (newAssetId == 0) {
+        throw new Error('Manager does not have asset to testing clawback.');
+      }
+
+      // Ensure the clawback user is opted in (receiver must be opted-in for clawback to succeed)
+      const optInClawbackUserResponse = await axios.post(
+        `${APP_BASE_URL}/wallet/transactions/transfer-asset`,
+        { assetId: Number(newAssetId), userId: clawbackUserId, fromUserId: 'manager', amount: 1 },
+        { headers: { Authorization: `Bearer ${managerAccessToken}` } },
+      );
+      expect(optInClawbackUserResponse.status).toBe(201);
+
+      // Transfer one unit of the asset to the target user
+      const transferResponse = await axios.post(
+        `${APP_BASE_URL}/wallet/transactions/transfer-asset`,
+        { assetId: Number(newAssetId), userId: targetUserId, fromUserId: 'manager', amount: 1 },
+        { headers: { Authorization: `Bearer ${managerAccessToken}` } },
+      );
+      expect(transferResponse.status).toBe(201);
+
+      // Login with user role and clawback as the clawback user
+      const userVaultToken = await loginToVault(USER_ROLE_AND_SECRET);
+      const userAccessToken = await signInToPawn(userVaultToken);
+
+      await expect(
+        axios.post(`${APP_BASE_URL}/wallet/transactions/clawback-asset`, {
+          assetId: Number(newAssetId),
+          userId: targetUserId,
+          fromUserId: userId,
+          amount: 1,
+        }, {
+          headers: { Authorization: `Bearer ${managerAccessToken}` },
+        }),
+      ).rejects.toMatchObject({ response: { status: 400 } }); // HTTP 400 Bad Request
+
+    }, 60000);
+    
   });
 
   describe('App deploy', () => {

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -428,7 +428,7 @@ describe('App E2E', () => {
     }, 60000); 
   });
 
-  describe.only('Transfer Algo', () => {
+  describe('Transfer Algo', () => {
     it('(OK) transfer algo to address from manager', async () => {
       const vaultToken = await loginToVault(MANAGER_ROLE_AND_SECRET);
       const managerAccessToken = await signInToPawn(vaultToken);
@@ -859,6 +859,7 @@ describe('App E2E', () => {
     const assetClawbackRequestData = {
       assetId: 1,
       userId: 'test-user-id',
+      fromUserId: 'manager',
       amount: 1,
     };
 
@@ -979,6 +980,87 @@ describe('App E2E', () => {
       ).rejects.toMatchObject({ response: { status: 403 } });
     }, 60000);
 
+    it('(OK) clawback asset with user role and user as signer', async () => {
+      const managerVaultToken = await loginToVault(MANAGER_ROLE_AND_SECRET);
+      const managerAccessToken = await signInToPawn(managerVaultToken);
+
+      // Create a user who will be set as the asset clawback address (and signer)
+      const { userId: clawbackUserId, createUserResponse: clawbackUser } = await createNewUser(managerAccessToken);
+      expect(clawbackUser.status).toBe(201);
+
+      // Create a target user who will receive the asset and then be clawed back
+      const { userId: targetUserId, createUserResponse: targetUser } = await createNewUser(managerAccessToken);
+      expect(targetUser.status).toBe(201);
+
+      // Ensure clawback user has enough ALGO to pay transaction fees
+      const fundClawbackUser = await axios.post(
+        `${APP_BASE_URL}/wallet/transactions/transfer-algo`,
+        { fromUserId: 'manager', toAddress: clawbackUser.data.public_address, amount: 500000 },
+        { headers: { Authorization: `Bearer ${managerAccessToken}` } },
+      );
+      expect(fundClawbackUser.status).toBe(201);
+
+      const managerAddress = await getManagerAddress();
+      const assetData = {
+        total: 100000,
+        decimals: 0,
+        defaultFrozen: false,
+        unitName: 'Tas',
+        assetName: 'Tennnnnnnnnnnnnnnnnn',
+        url: 'https://example.com',
+        fromUserId: 'manager',
+        clawbackAddress: clawbackUser.data.public_address,
+      };
+      const createAssetResponse = await axios.post(`${APP_BASE_URL}/wallet/transactions/create-asset`, assetData, {
+        headers: { Authorization: `Bearer ${managerAccessToken}` },
+      });
+      expect(createAssetResponse.status).toBe(201);
+
+      const managerDetail = await getAccountDetail(managerAddress);
+      const newAssetId = managerDetail.assets.reduce((max, current) => (current.assetId > max.assetId ? current : max), {
+        assetId: 0,
+      }).assetId;
+      if (newAssetId == 0) {
+        throw new Error('Manager does not have asset to testing clawback.');
+      }
+
+      // Ensure the clawback user is opted in (receiver must be opted-in for clawback to succeed)
+      const optInClawbackUserResponse = await axios.post(
+        `${APP_BASE_URL}/wallet/transactions/transfer-asset`,
+        { assetId: Number(newAssetId), userId: clawbackUserId, fromUserId: 'manager', amount: 1 },
+        { headers: { Authorization: `Bearer ${managerAccessToken}` } },
+      );
+      expect(optInClawbackUserResponse.status).toBe(201);
+
+      // Transfer one unit of the asset to the target user
+      const transferResponse = await axios.post(
+        `${APP_BASE_URL}/wallet/transactions/transfer-asset`,
+        { assetId: Number(newAssetId), userId: targetUserId, fromUserId: 'manager', amount: 1 },
+        { headers: { Authorization: `Bearer ${managerAccessToken}` } },
+      );
+      expect(transferResponse.status).toBe(201);
+
+      // Login with user role and clawback as the clawback user
+      const userVaultToken = await loginToVault(USER_ROLE_AND_SECRET);
+      const userAccessToken = await signInToPawn(userVaultToken);
+
+      const clawbackResponse = await axios.post(
+        `${APP_BASE_URL}/wallet/transactions/clawback-asset`,
+        { assetId: Number(newAssetId), userId: targetUserId, fromUserId: clawbackUserId, amount: 1 },
+        { headers: { Authorization: `Bearer ${userAccessToken}` } },
+      );
+      expect(clawbackResponse.status).toBe(201);
+      expect(typeof clawbackResponse.data.transaction_id).toEqual('string');
+
+      // Verify the target user no longer holds the asset
+      const targetAssets = await axios.get(`${APP_BASE_URL}/wallet/assets/${targetUserId}`, {
+        headers: { Authorization: `Bearer ${managerAccessToken}` },
+      });
+      expect(targetAssets.status).toBe(200);
+      const holding = (targetAssets.data.assets ?? []).find((a: any) => a['asset-id'] === Number(newAssetId));
+      expect(holding?.amount ?? 0).toEqual(0);
+    }, 60000);
+
     it('(FAIL) can not clawback asset without clawback address', async () => {
       // create asset without clawback address
       const vaultToken = await loginToVault(MANAGER_ROLE_AND_SECRET);
@@ -1033,11 +1115,17 @@ describe('App E2E', () => {
   });
 
   describe('App deploy', () => {
-    it('(OK) app deploy', async () => {
-      const vaultToken = await loginToVault(MANAGER_ROLE_AND_SECRET);
-      const managerAccessToken = await signInToPawn(vaultToken);
+    let managerAccessToken: string;
+    let deployedAppId = 0;
+    let userAccessToken: string;
+    let appUserId: string;
+    let userDeployedAppId = 0;
 
-      const appCallRequestData = {
+    beforeAll(async () => {
+      const vaultToken = await loginToVault(MANAGER_ROLE_AND_SECRET);
+      managerAccessToken = await signInToPawn(vaultToken);
+
+      const appCreateRequestData = {
         approvalProgram:
           'CiACAQAmAQQVH3x1MRtBAJaCBAQCvs4RBP5r32kEVH/6RwS4K+3YNhoAjgQAVQA8ACIAAiNDMRkURDEYRDYaAVcCADYaAhcxFiIJSTgQIhJEiAC0IkMxGRREMRhEMRYiCUk4ECISRDYaAReIAF0iQzEZFEQxGEQ2GgEXNhoCF4gAQBYoTFCwIkMxGRREMRhENhoBVwIAiAAZSRUWVwYCTFAoTFCwIkMxGUD/iDEYFEQiQ4oBAYAHSGVsbG8sIIv/UImKAgGL/ov/CImKAgCL/jgAMQASRIv+OAcyChJEMhAyAAiL/jgIEkQyCov/cABFARREsTIKI7ISshSL/7IRgQSyECOyAbOJigMAi/84BzIKEkSL/zgAMQASRIv+FoAHYm94X2ludEsBv4AKYm94X3N0cmluZ4v9UEy/iQ==',
         clearProgram: 'CoEBQw==',
@@ -1049,22 +1137,64 @@ describe('App E2E', () => {
         fromUserId: 'manager',
       };
 
-      const response = await axios.post(`${APP_BASE_URL}/wallet/transactions/app-call/`, appCallRequestData, {
+      const response = await axios.post(`${APP_BASE_URL}/wallet/transactions/app-call/`, appCreateRequestData, {
         headers: { Authorization: `Bearer ${managerAccessToken}` },
       });
-
       expect(response.status).toBe(201);
       expect(typeof response.data.transaction_id).toEqual('string');
+
+      const transaction = await getTransaction(response.data.transaction_id);
+      deployedAppId = transaction.transaction['created-application-index'] ?? 0;
+      expect(typeof deployedAppId).toEqual('number');
+      expect(deployedAppId).toBeGreaterThan(0);
+
+      const { userId, createUserResponse } = await createNewUser(managerAccessToken);
+      expect(createUserResponse.status).toBe(201);
+      appUserId = userId;
+
+      const fundUserResponse = await axios.post(
+        `${APP_BASE_URL}/wallet/transactions/transfer-algo`,
+        { fromUserId: 'manager', toAddress: createUserResponse.data.public_address, amount: 500000 },
+        { headers: { Authorization: `Bearer ${managerAccessToken}` } },
+      );
+      expect(fundUserResponse.status).toBe(201);
+
+      const userVaultToken = await loginToVault(USER_ROLE_AND_SECRET);
+      userAccessToken = await signInToPawn(userVaultToken);
+
+      const userAppCreateRequestData = {
+        approvalProgram:
+          'CiACAQAmAQQVH3x1MRtBAJaCBAQCvs4RBP5r32kEVH/6RwS4K+3YNhoAjgQAVQA8ACIAAiNDMRkURDEYRDYaAVcCADYaAhcxFiIJSTgQIhJEiAC0IkMxGRREMRhEMRYiCUk4ECISRDYaAReIAF0iQzEZFEQxGEQ2GgEXNhoCF4gAQBYoTFCwIkMxGRREMRhENhoBVwIAiAAZSRUWVwYCTFAoTFCwIkMxGUD/iDEYFEQiQ4oBAYAHSGVsbG8sIIv/UImKAgGL/ov/CImKAgCL/jgAMQASRIv+OAcyChJEMhAyAAiL/jgIEkQyCov/cABFARREsTIKI7ISshSL/7IRgQSyECOyAbOJigMAi/84BzIKEkSL/zgAMQASRIv+FoAHYm94X2ludEsBv4AKYm94X3N0cmluZ4v9UEy/iQ==',
+        clearProgram: 'CoEBQw==',
+        globalByteSlices: 1,
+        globalInts: 1,
+        localByteSlices: 0,
+        localInts: 0,
+        onComplete: 0,
+        fromUserId: appUserId,
+      };
+
+      const userCreateResponse = await axios.post(`${APP_BASE_URL}/wallet/transactions/app-call/`, userAppCreateRequestData, {
+        headers: { Authorization: `Bearer ${userAccessToken}` },
+      });
+      expect(userCreateResponse.status).toBe(201);
+      expect(typeof userCreateResponse.data.transaction_id).toEqual('string');
+
+      const userCreateTxn = await getTransaction(userCreateResponse.data.transaction_id);
+      userDeployedAppId = userCreateTxn.transaction['created-application-index'] ?? 0;
+      expect(typeof userDeployedAppId).toEqual('number');
+      expect(userDeployedAppId).toBeGreaterThan(0);
     }, 60000);
-  });
 
-  describe('App abi method call with string args', () => {
+    afterAll(() => {
+      deployedAppId = 0;
+      userDeployedAppId = 0;
+    });
+
     it('(OK) App abi method call with string args', async () => {
-      const vaultToken = await loginToVault(MANAGER_ROLE_AND_SECRET);
-      const managerAccessToken = await signInToPawn(vaultToken);
-
+      expect(deployedAppId).toBeGreaterThan(0);
       const appCallRequestData = {
-        appId: 754755349,
+        appId: deployedAppId,
         args: {
           name: 'hello',
           args: [
@@ -1087,15 +1217,11 @@ describe('App E2E', () => {
       expect(response.status).toBe(201);
       expect(typeof response.data.transaction_id).toEqual('string');
     }, 60000);
-  });
 
-  describe('App abi method call with uint64 args', () => {
     it('(OK) App abi method call with uint64 args', async () => {
-      const vaultToken = await loginToVault(MANAGER_ROLE_AND_SECRET);
-      const managerAccessToken = await signInToPawn(vaultToken);
-
+      expect(deployedAppId).toBeGreaterThan(0);
       const appCallRequestData = {
-        appId: 754755349,
+        appId: deployedAppId,
         args: {
           name: 'add',
           args: [
@@ -1121,102 +1247,277 @@ describe('App E2E', () => {
       expect(response.status).toBe(201);
       expect(typeof response.data.transaction_id).toEqual('string');
     }, 60000);
-  });
 
-  describe('Group transaction (foreign Accounts and Assets)', () => {
-    it('(OK) Group call with payment and app call with foreign Accounts and Assets', async () => {
-      const vaultToken = await loginToVault(MANAGER_ROLE_AND_SECRET);
-      const managerAccessToken = await signInToPawn(vaultToken);
-
-      const groupRequestData = {
-        transactions: [
-          {
-            type: 'payment',
-            payload: {
-              toAddress: 'CHIJEK5EF3DD6EHCM23CV6IXO7JI4YIOHGN6755G6X3NQVYVKJV3WM7M2A',
-              amount: 101000,
-              fromUserId: 'manager',
-              note: 'optional note',
-              lease: '9kykoZ1IpuOAqhzDgRVaVY2ME0ZlCNrUpnzxpXlEF/s=',
+    it('(OK) user should able to call abi methods', async () => {
+      expect(userDeployedAppId).toBeGreaterThan(0);
+      const appCallRequestData = {
+        appId: userDeployedAppId,
+        args: {
+          name: 'hello',
+          args: [
+            {
+              type: 'string',
+              value: 'world',
             },
+          ],
+          returns: {
+            type: 'string',
           },
-          {
-            type: 'appCall',
-            payload: {
-              appId: 754755349,
-              onComplete: 0,
-              fromUserId: 'manager',
-              fee: 2000,
-              args: {
-                name: 'opt_in_token',
-                args: [
-                  { type: 'pay', value: null },
-                  { type: 'uint64', value: 723769800 },
-                ],
-                returns: { type: 'void' },
-              },
-              foreignAccounts: ['CHIJEK5EF3DD6EHCM23CV6IXO7JI4YIOHGN6755G6X3NQVYVKJV3WM7M2A'],
-              foreignAssets: [723769800],
-            },
-          },
-        ],
+        },
+        fromUserId: appUserId,
       };
 
-      const response = await axios.post(`${APP_BASE_URL}/wallet/transactions/group-transaction/`, groupRequestData, {
-        headers: { Authorization: `Bearer ${managerAccessToken}` },
+      const response = await axios.post(`${APP_BASE_URL}/wallet/transactions/app-call/`, appCallRequestData, {
+        headers: { Authorization: `Bearer ${userAccessToken}` },
       });
 
       expect(response.status).toBe(201);
-      expect(typeof response.data.group_id).toEqual('string');
+      expect(typeof response.data.transaction_id).toEqual('string');
+    }, 60000);
+
+    it('(FAIL) user role should not be able to call any abi method as manager', async () => {
+      const appCallRequestData = {
+        appId: deployedAppId,
+        args: {
+          name: 'hello',
+          args: [
+            {
+              type: 'string',
+              value: 'world',
+            },
+          ],
+          returns: {
+            type: 'string',
+          },
+        },
+        fromUserId: 'manager',
+      };
+
+      await expect(
+        axios.post(`${APP_BASE_URL}/wallet/transactions/app-call/`, appCallRequestData, {
+          headers: { Authorization: `Bearer ${userAccessToken}` },
+        }),
+      ).rejects.toMatchObject({ response: { status: 403 } });
     }, 60000);
   });
 
-  describe('Group transaction (foreign apps and boxes)', () => {
-    it('(OK) Group call with payment and app call with foreign Apps and Boxes', async () => {
-      const vaultToken = await loginToVault(MANAGER_ROLE_AND_SECRET);
-      const managerAccessToken = await signInToPawn(vaultToken);
+  describe.only('Group transactions', () => {
+    let managerAccessToken: string;
+    let deployedAppId = 0;
+    let deployedAppAddress: string;
+    let tokenAssetId = 0;
+    let userAccessToken: string;
+    let groupUserId: string;
+    let userDeployedAppId = 0;
 
-      const groupRequestData = {
-        transactions: [
-          {
-            type: 'payment',
-            payload: {
-              toAddress: 'CHIJEK5EF3DD6EHCM23CV6IXO7JI4YIOHGN6755G6X3NQVYVKJV3WM7M2A',
-              amount: 100000,
-              fromUserId: 'manager',
-              note: 'optional note',
-              lease: '9kykoZ1IpuOAqhzDgRVaVY2ME0ZlCNrUpnzxpXlEF/s=',
-            },
-          },
-          {
-            type: 'appCall',
-            payload: {
-              appId: 754755349,
-              onComplete: 0,
-              fromUserId: 'manager',
-              fee: 2000,
-              args: {
-                name: 'create_box_paid',
-                args: [
-                  { type: 'string', value: 'abc' },
-                  { type: 'uint64', value: 123 },
-                  { type: 'pay', value: null },
-                ],
-                returns: { type: 'void' },
-              },
-              foreignApps: [754755349],
-              boxes: [{ n: 'Ym94X2ludA==' }, { n: 'Ym94X3N0cmluZ2FiYw==' }],
-            },
-          },
-        ],
+    beforeAll(async () => {
+      const vaultToken = await loginToVault(MANAGER_ROLE_AND_SECRET);
+      managerAccessToken = await signInToPawn(vaultToken);
+
+      deployedAppId = 754755349;
+      deployedAppAddress = 'CHIJEK5EF3DD6EHCM23CV6IXO7JI4YIOHGN6755G6X3NQVYVKJV3WM7M2A';
+      tokenAssetId = 723769800;
+
+      const { userId, createUserResponse } = await createNewUser(managerAccessToken);
+      expect(createUserResponse.status).toBe(201);
+      groupUserId = userId;
+
+      const fundUserResponse = await axios.post(
+        `${APP_BASE_URL}/wallet/transactions/transfer-algo`,
+        { fromUserId: 'manager', toAddress: createUserResponse.data.public_address, amount: 500000 },
+        { headers: { Authorization: `Bearer ${managerAccessToken}` } },
+      );
+      expect(fundUserResponse.status).toBe(201);
+
+      const userVaultToken = await loginToVault(USER_ROLE_AND_SECRET);
+      userAccessToken = await signInToPawn(userVaultToken);
+
+      const userAppCreateRequestData = {
+        approvalProgram:
+          'CiACAQAmAQQVH3x1MRtBAJaCBAQCvs4RBP5r32kEVH/6RwS4K+3YNhoAjgQAVQA8ACIAAiNDMRkURDEYRDYaAVcCADYaAhcxFiIJSTgQIhJEiAC0IkMxGRREMRhEMRYiCUk4ECISRDYaAReIAF0iQzEZFEQxGEQ2GgEXNhoCF4gAQBYoTFCwIkMxGRREMRhENhoBVwIAiAAZSRUWVwYCTFAoTFCwIkMxGUD/iDEYFEQiQ4oBAYAHSGVsbG8sIIv/UImKAgGL/ov/CImKAgCL/jgAMQASRIv+OAcyChJEMhAyAAiL/jgIEkQyCov/cABFARREsTIKI7ISshSL/7IRgQSyECOyAbOJigMAi/84BzIKEkSL/zgAMQASRIv+FoAHYm94X2ludEsBv4AKYm94X3N0cmluZ4v9UEy/iQ==',
+        clearProgram: 'CoEBQw==',
+        globalByteSlices: 1,
+        globalInts: 1,
+        localByteSlices: 0,
+        localInts: 0,
+        onComplete: 0,
+        fromUserId: groupUserId,
       };
 
-      const response = await axios.post(`${APP_BASE_URL}/wallet/transactions/group-transaction/`, groupRequestData, {
-        headers: { Authorization: `Bearer ${managerAccessToken}` },
+      const userCreateResponse = await axios.post(`${APP_BASE_URL}/wallet/transactions/app-call/`, userAppCreateRequestData, {
+        headers: { Authorization: `Bearer ${userAccessToken}` },
       });
+      expect(userCreateResponse.status).toBe(201);
+      expect(typeof userCreateResponse.data.transaction_id).toEqual('string');
 
-      expect(response.status).toBe(201);
-      expect(typeof response.data.group_id).toEqual('string');
+      const userCreateTxn = await getTransaction(userCreateResponse.data.transaction_id);
+      userDeployedAppId = userCreateTxn.transaction['created-application-index'] ?? 0;
+      expect(typeof userDeployedAppId).toEqual('number');
+      expect(userDeployedAppId).toBeGreaterThan(0);
     }, 60000);
+
+    afterAll(() => {
+      deployedAppId = 0;
+      userDeployedAppId = 0;
+    });
+
+    describe('Group transaction (foreign Accounts and Assets)', () => {
+      it('(OK) Group call with payment and app call with foreign Accounts and Assets', async () => {
+        const groupRequestData = {
+          transactions: [
+            {
+              type: 'payment',
+              payload: {
+                toAddress: deployedAppAddress,
+                amount: 101000,
+                fromUserId: 'manager',
+                note: 'optional note',
+                lease: '9kykoZ1IpuOAqhzDgRVaVY2ME0ZlCNrUpnzxpXlEF/s=',
+              },
+            },
+            {
+              type: 'appCall',
+              payload: {
+                appId: deployedAppId,
+                onComplete: 0,
+                fromUserId: 'manager',
+                fee: 2000,
+                args: {
+                  name: 'opt_in_token',
+                  args: [
+                    { type: 'pay', value: null },
+                    { type: 'uint64', value: tokenAssetId },
+                  ],
+                  returns: { type: 'void' },
+                },
+                foreignAccounts: [deployedAppAddress],
+                foreignAssets: [tokenAssetId],
+              },
+            },
+          ],
+        };
+
+        const response = await axios.post(`${APP_BASE_URL}/wallet/transactions/group-transaction/`, groupRequestData, {
+          headers: { Authorization: `Bearer ${managerAccessToken}` },
+        });
+
+        expect(response.status).toBe(201);
+        expect(typeof response.data.group_id).toEqual('string');
+      }, 60000);
+    });
+
+    describe('Group transaction (foreign apps and boxes)', () => {
+      it('(OK) Group call with payment and app call with foreign Apps and Boxes', async () => {
+        const groupRequestData = {
+          transactions: [
+            {
+              type: 'payment',
+              payload: {
+                toAddress: deployedAppAddress,
+                amount: 100000,
+                fromUserId: 'manager',
+                note: 'optional note',
+                lease: '9kykoZ1IpuOAqhzDgRVaVY2ME0ZlCNrUpnzxpXlEF/s=',
+              },
+            },
+            {
+              type: 'appCall',
+              payload: {
+                appId: deployedAppId,
+                onComplete: 0,
+                fromUserId: 'manager',
+                fee: 2000,
+                args: {
+                  name: 'create_box_paid',
+                  args: [
+                    { type: 'string', value: 'abc' },
+                    { type: 'uint64', value: 123 },
+                    { type: 'pay', value: null },
+                  ],
+                  returns: { type: 'void' },
+                },
+                foreignApps: [deployedAppId],
+                boxes: [{ n: 'Ym94X2ludA==' }, { n: 'Ym94X3N0cmluZ2FiYw==' }],
+              },
+            },
+          ],
+        };
+
+        const response = await axios.post(`${APP_BASE_URL}/wallet/transactions/group-transaction/`, groupRequestData, {
+          headers: { Authorization: `Bearer ${managerAccessToken}` },
+        });
+
+        expect(response.status).toBe(201);
+        expect(typeof response.data.group_id).toEqual('string');
+      }, 60000);
+    });
+
+    describe('Group transaction (user scoped)', () => {
+      it('(FAIL) user role should not be able to sign any group transaction as manager', async () => {
+        const groupRequestData = {
+          transactions: [
+            {
+              type: 'payment',
+              payload: {
+                toAddress: deployedAppAddress,
+                amount: 100000,
+                fromUserId: 'manager',
+              },
+            },
+            {
+              type: 'payment',
+              payload: {
+                toAddress: deployedAppAddress,
+                amount: 1000,
+                fromUserId: groupUserId,
+              },
+            },
+          ],
+        };
+
+        await expect(
+          axios.post(`${APP_BASE_URL}/wallet/transactions/group-transaction/`, groupRequestData, {
+            headers: { Authorization: `Bearer ${userAccessToken}` },
+          }),
+        ).rejects.toMatchObject({ response: { status: 403 } });
+      }, 60000);
+
+      it('(OK) user role should be able to submit group transaction when all txns are user-signed', async () => {
+        expect(userDeployedAppId).toBeGreaterThan(0);
+
+        const groupRequestData = {
+          transactions: [
+            {
+              type: 'payment',
+              payload: {
+                toAddress: deployedAppAddress,
+                amount: 1000,
+                fromUserId: groupUserId,
+              },
+            },
+            {
+              type: 'appCall',
+              payload: {
+                appId: userDeployedAppId,
+                onComplete: 0,
+                fromUserId: groupUserId,
+                args: {
+                  name: 'hello',
+                  args: [{ type: 'string', value: 'world' }],
+                  returns: { type: 'string' },
+                },
+              },
+            },
+          ],
+        };
+
+        const response = await axios.post(`${APP_BASE_URL}/wallet/transactions/group-transaction/`, groupRequestData, {
+          headers: { Authorization: `Bearer ${userAccessToken}` },
+        });
+
+        expect(response.status).toBe(201);
+        expect(typeof response.data.group_id).toEqual('string');
+      }, 60000);
+    });
   });
 });

--- a/vault/development-init.ts
+++ b/vault/development-init.ts
@@ -162,6 +162,10 @@ async function createACLPolicies(token: string) {
           [`${VAULT_TRANSIT_USERS_PATH}/keys/+/+`]: {
             capabilities: ['deny'],
           },
+          // 4 allow /sign path
+          [`${VAULT_TRANSIT_USERS_PATH}/sign/*`]: {
+            capabilities: ['create', 'read', 'update'],
+          },
         },
       },
       [MANAGERS_POLICY_NAME]: {


### PR DESCRIPTION
## Summary
This PR makes wallet transaction endpoints consistently support **who signs** each transaction via `fromUserId` (`manager` vs user) and ensures **user-scoped** and **manager-scoped** authorization behaves correctly (e.g., user tokens cannot sign as manager and return `403` instead of `500`). It also expands/refactors E2E coverage to validate the updated behavior across asset creation, asset transfer, app calls, and group transactions.

### Correct error semantics for user-scoped tokens
- Ensure user tokens attempting manager-only operations return **`403 Forbidden`** rather than bubbling up as **`500 Internal Server Error`**
  - (notably around transfer-algo / signing-as-manager paths)
  
## Testing / Coverage Improvements
- Refactor E2E tests to reuse a common [createNewUser()] helper.
- Asset ACL update flow using assetId
- Add/expand E2E scenarios validating with user and manager scoped token:
  - user-scoped vs manager-scoped authorization
  - asset transfer flows (including lease replay protection)
  - asset clawback signer behavior
  - app deploy + app call flows
  - group tx success cases for:
    - manager-only signer groups
    - user-only signer groups (including 2-user flows)
  - group tx failure case for mixed signers with user scoped token  
